### PR TITLE
feat: Telegram Bot remote chat service

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -86,6 +86,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "aquamarine"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
+dependencies = [
+ "include_dir",
+ "itertools 0.10.5",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +946,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
@@ -952,6 +976,20 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
@@ -960,7 +998,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.114",
 ]
 
@@ -974,8 +1012,19 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1242,6 +1291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dptree"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81175dab5ec79c30e0576df2ed2c244e1721720c302000bb321b107e82e265c"
+dependencies = [
+ "futures",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,7 +1346,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1364,6 +1422,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erasable"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437cfb75878119ed8265685c41a115724eae43fb7cc5a0bf0e4ecc3b803af1c4"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "erased-serde"
@@ -2410,6 +2478,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -2442,7 +2523,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
- "system-configuration",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -2638,6 +2719,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2726,6 +2826,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -4554,7 +4663,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -4617,7 +4726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -4629,6 +4738,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rc-box"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897fecc9fac6febd4408f9e935e86df739b0023b625e610e0357535b9c8adad0"
+dependencies = [
+ "erasable",
 ]
 
 [[package]]
@@ -4728,6 +4846,49 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
@@ -4743,7 +4904,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -4758,7 +4919,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -4795,7 +4956,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",
  "tower",
@@ -4962,6 +5123,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -5261,6 +5431,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
 version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
@@ -5274,8 +5454,20 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
- "serde_with_macros",
+ "serde_with_macros 3.16.1",
  "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5762,6 +5954,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -5807,6 +6005,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -5841,13 +6045,34 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5872,6 +6097,18 @@ dependencies = [
  "toml 0.8.2",
  "version-compare",
 ]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "takecell"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20f34339676cdcab560c9a82300c4c2581f68b9369aedf0fae86f2ff9565ff3e"
 
 [[package]]
 name = "tao"
@@ -6009,6 +6246,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
+ "teloxide",
  "tempfile",
  "tokio",
  "tokio-test",
@@ -6241,7 +6479,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "serde_json",
- "serde_with",
+ "serde_with 3.16.1",
  "swift-rs",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
@@ -6260,6 +6498,74 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "teloxide"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f79dd283eb21b90451c03fa7c7f83b9985130efb876b33bad89a2c208ccbc16"
+dependencies = [
+ "aquamarine",
+ "bytes",
+ "derive_more",
+ "dptree",
+ "either",
+ "futures",
+ "log",
+ "mime",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "teloxide-core",
+ "teloxide-macros",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "teloxide-core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1642a7ef10e7af63b8298c8d13c0f986d4fc646d42649ff060359607f62f69"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytes",
+ "chrono",
+ "derive_more",
+ "either",
+ "futures",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project",
+ "rc-box",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "serde_with 1.14.0",
+ "take_mut",
+ "takecell",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "teloxide-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2d33d809c3e7161a9ab18bedddf98821245014f0a78fa4d2c9430b2ec018c1"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6409,7 +6715,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -6629,7 +6935,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -8033,6 +8339,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ warp = "0.3"
 filetime = "0.2"
 xcap = "0.0.14"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+teloxide = { version = "0.13", features = ["macros"] }
 
 [features]
 stress = []

--- a/src-tauri/src/commands/live2d.rs
+++ b/src-tauri/src/commands/live2d.rs
@@ -158,6 +158,104 @@ pub async fn delete_live2d_model(app: tauri::AppHandle, model_name: String) -> R
     Ok(())
 }
 
+/// Import a Live2D model from an extracted folder (by its .model3.json path).
+///
+/// Finds the model root directory (the folder containing .moc3), copies the
+/// entire folder into `{app_data_dir}/live2d_models/{folder_name}/`, and
+/// returns the relative path to the .model3.json (same format as zip import).
+#[tauri::command]
+pub async fn import_live2d_folder(
+    app: tauri::AppHandle,
+    model_json_path: String,
+) -> Result<String, String> {
+    let json_path = std::path::Path::new(&model_json_path);
+    if !json_path.exists() {
+        return Err("model3.json file does not exist".to_string());
+    }
+
+    // Walk up from the .model3.json to find the model root (directory containing a .moc3 file)
+    let model_root = find_model_root(json_path)
+        .ok_or_else(|| "Cannot find model root directory (no .moc3 file found in parent directories)".to_string())?;
+
+    let folder_name = model_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "Invalid folder name".to_string())?
+        .to_string();
+
+    // Determine target directory
+    let app_data = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Cannot resolve app data dir: {}", e))?;
+    let models_dir = app_data.join("live2d_models");
+    let target_dir = models_dir.join(&folder_name);
+
+    // If target already exists, remove it first (re-import scenario)
+    if target_dir.exists() {
+        fs::remove_dir_all(&target_dir)
+            .map_err(|e| format!("Failed to remove existing model folder: {}", e))?;
+    }
+
+    // Copy the entire model folder
+    copy_dir_recursive(&model_root, &target_dir)
+        .map_err(|e| format!("Failed to copy model folder: {}", e))?;
+
+    // Validate the copy by finding .model3.json in the target
+    let model_json = find_model3_json(&target_dir)
+        .ok_or_else(|| "Copied folder does not contain a .model3.json file".to_string())?;
+
+    let relative = model_json
+        .strip_prefix(&models_dir)
+        .map_err(|e| format!("Failed to compute relative path: {}", e))?;
+
+    let relative_str = relative.to_string_lossy().replace('\\', "/");
+
+    Ok(relative_str)
+}
+
+/// Walk up from a .model3.json file to find the model root directory.
+/// The root is the directory (or an ancestor) that contains a .moc3 file.
+fn find_model_root(model_json: &std::path::Path) -> Option<PathBuf> {
+    let mut dir = model_json.parent()?;
+    loop {
+        if dir_contains_moc3(dir) {
+            return Some(dir.to_path_buf());
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// Check if a directory directly contains a .moc3 file.
+fn dir_contains_moc3(dir: &std::path::Path) -> bool {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            if let Some(name) = entry.path().file_name().and_then(|n| n.to_str()) {
+                if name.ends_with(".moc3") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Recursively copy a directory and all its contents.
+fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else {
+            fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
 fn find_model3_json(dir: &std::path::Path) -> Option<PathBuf> {
     let entries = fs::read_dir(dir).ok()?;
     let mut dirs = Vec::new();

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14,5 +14,6 @@ pub mod mods;
 pub mod singing;
 pub mod stt;
 pub mod system;
+pub mod telegram;
 pub mod tts;
 pub mod vision;

--- a/src-tauri/src/commands/telegram.rs
+++ b/src-tauri/src/commands/telegram.rs
@@ -1,0 +1,63 @@
+//! Telegram Bot IPC commands — frontend ↔ backend bridge.
+
+use crate::telegram::TelegramService;
+use serde::Serialize;
+use tauri::State;
+
+#[derive(Serialize)]
+pub struct TelegramStatus {
+    pub running: bool,
+    pub enabled: bool,
+    pub has_token: bool,
+}
+
+#[tauri::command]
+pub async fn get_telegram_config(
+    state: State<'_, TelegramService>,
+) -> Result<crate::telegram::TelegramConfig, String> {
+    Ok(state.get_config().await)
+}
+
+#[tauri::command]
+pub async fn save_telegram_config(
+    state: State<'_, TelegramService>,
+    config: crate::telegram::TelegramConfig,
+) -> Result<(), String> {
+    // Persist to disk
+    let app_data = dirs_next::data_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("com.chyin.kokoro");
+    let config_path = app_data.join("telegram_config.json");
+    crate::telegram::save_config(&config_path, &config)?;
+
+    // Update in-memory config
+    state.update_config(config).await;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn start_telegram_bot(
+    state: State<'_, TelegramService>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
+    state.start(app).await
+}
+
+#[tauri::command]
+pub async fn stop_telegram_bot(
+    state: State<'_, TelegramService>,
+) -> Result<(), String> {
+    state.stop().await
+}
+
+#[tauri::command]
+pub async fn get_telegram_status(
+    state: State<'_, TelegramService>,
+) -> Result<TelegramStatus, String> {
+    let config = state.get_config().await;
+    Ok(TelegramStatus {
+        running: state.is_running().await,
+        enabled: config.enabled,
+        has_token: config.resolve_bot_token().is_some(),
+    })
+}

--- a/src-tauri/src/telegram/bot.rs
+++ b/src-tauri/src/telegram/bot.rs
@@ -1,0 +1,730 @@
+//! Telegram Bot core — message handling, command dispatch, and AI pipeline bridge.
+
+use super::config::TelegramConfig;
+use crate::ai::context::AIOrchestrator;
+use crate::imagegen::ImageGenService;
+use crate::llm::service::LlmService;
+use crate::stt::{AudioSource, SttService};
+use crate::tts::TtsService;
+use futures::StreamExt;
+use std::collections::HashMap;
+use std::sync::Arc;
+use serde::Serialize;
+use tauri::{Emitter, Manager};
+use teloxide::prelude::*;
+use teloxide::types::InputFile;
+use tokio::sync::{oneshot, RwLock};
+
+/// Per-chat session state.
+#[derive(Clone, Debug)]
+enum SessionMode {
+    /// Continue the desktop conversation (default).
+    Continue,
+    /// Fresh conversation started via /new.
+    New,
+}
+
+type Sessions = Arc<RwLock<HashMap<ChatId, SessionMode>>>;
+
+/// Event payload for syncing Telegram messages to the desktop chat UI.
+#[derive(Clone, Serialize)]
+struct TelegramChatSync {
+    role: String,
+    text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    translation: Option<String>,
+}
+
+/// Run the long-polling loop. Blocks until `shutdown_rx` fires or an error occurs.
+pub async fn run_polling(
+    token: String,
+    config: TelegramConfig,
+    app: tauri::AppHandle,
+    shutdown_rx: oneshot::Receiver<()>,
+) {
+    let bot = Bot::new(&token);
+    let config = Arc::new(config);
+    let sessions: Sessions = Arc::new(RwLock::new(HashMap::new()));
+
+    // Build the update handler
+    let handler = Update::filter_message().endpoint(handle_message);
+
+    let mut dispatcher = Dispatcher::builder(bot.clone(), handler)
+        .dependencies(dptree::deps![config.clone(), sessions.clone(), app.clone()])
+        .default_handler(|_upd| async {})
+        .build();
+
+    // Run dispatcher in a spawned task so we can select on shutdown
+    let shutdown_token = dispatcher.shutdown_token();
+    tauri::async_runtime::spawn(async move {
+        dispatcher.dispatch().await;
+    });
+
+    // Wait for shutdown signal
+    let _ = shutdown_rx.await;
+    shutdown_token
+        .shutdown()
+        .expect("Failed to shutdown dispatcher")
+        .await;
+}
+
+/// Central message handler — dispatches commands and regular messages.
+async fn handle_message(
+    bot: Bot,
+    msg: Message,
+    config: Arc<TelegramConfig>,
+    sessions: Sessions,
+    app: tauri::AppHandle,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let chat_id = msg.chat.id;
+    println!("[Telegram] Received message from chat_id={}, text={:?}", chat_id.0, msg.text());
+
+    // Access control: check whitelist
+    if !config.allowed_chat_ids.is_empty()
+        && !config.allowed_chat_ids.contains(&chat_id.0)
+    {
+        println!("[Telegram] Chat {} not in whitelist, ignoring", chat_id.0);
+        return Ok(());
+    }
+
+    // Check for commands
+    if let Some(text) = msg.text() {
+        if text.starts_with('/') {
+            return handle_command(&bot, &msg, text, &config, &sessions, &app).await;
+        }
+    }
+
+    // Voice message
+    if msg.voice().is_some() {
+        return handle_voice(&bot, &msg, &config, &sessions, &app).await;
+    }
+
+    // Photo message (with optional caption)
+    if msg.photo().is_some() {
+        return handle_photo(&bot, &msg, &config, &app).await;
+    }
+
+    // Regular text message
+    if let Some(text) = msg.text() {
+        return handle_text(&bot, &msg, text, &config, &app).await;
+    }
+
+    Ok(())
+}
+
+/// Handle bot commands: /start, /new, /continue, /status
+async fn handle_command(
+    bot: &Bot,
+    msg: &Message,
+    text: &str,
+    _config: &Arc<TelegramConfig>,
+    sessions: &Sessions,
+    app: &tauri::AppHandle,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let chat_id = msg.chat.id;
+    let cmd = text.split_whitespace().next().unwrap_or("");
+
+    match cmd {
+        "/start" => {
+            let text = "Kokoro Engine — Telegram Bridge\n\n\
+                Commands:\n\
+                /continue — Resume the desktop conversation\n\
+                /new — Start a fresh conversation\n\
+                /status — Show current session info\n\n\
+                Just send a text or voice message to chat!";
+            if let Err(e) = bot.send_message(chat_id, text).await {
+                eprintln!("[Telegram] Failed to send /start reply: {}", e);
+            }
+        }
+        "/new" => {
+            // Clear orchestrator history to start fresh
+            if let Some(orchestrator) = app.try_state::<AIOrchestrator>() {
+                let mut history = orchestrator.history.lock().await;
+                history.clear();
+                drop(history);
+                let mut conv_id = orchestrator.current_conversation_id.lock().await;
+                *conv_id = None;
+            }
+            {
+                let mut s = sessions.write().await;
+                s.insert(chat_id, SessionMode::New);
+            }
+            bot.send_message(chat_id, "✨ New conversation started.")
+                .await
+                .ok();
+        }
+        "/continue" => {
+            {
+                let mut s = sessions.write().await;
+                s.insert(chat_id, SessionMode::Continue);
+            }
+            bot.send_message(chat_id, "🔗 Continuing desktop conversation.")
+                .await
+                .ok();
+        }
+        "/status" => {
+            let mode = {
+                let s = sessions.read().await;
+                s.get(&chat_id).cloned().unwrap_or(SessionMode::Continue)
+            };
+            let mode_str = match mode {
+                SessionMode::Continue => "Continue (desktop)",
+                SessionMode::New => "New conversation",
+            };
+            let history_len = if let Some(orchestrator) = app.try_state::<AIOrchestrator>() {
+                orchestrator.history.lock().await.len()
+            } else {
+                0
+            };
+            bot.send_message(
+                chat_id,
+                format!(
+                    "📊 Session: {}\n💬 History: {} messages",
+                    mode_str, history_len
+                ),
+            )
+            .await
+            .ok();
+        }
+        _ => {
+            // Unknown command — treat as text
+            let clean = text.trim_start_matches('/');
+            if !clean.is_empty() {
+                handle_text(bot, msg, text, _config, app).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Handle a plain text message — run through the LLM pipeline and reply.
+async fn handle_text(
+    bot: &Bot,
+    msg: &Message,
+    text: &str,
+    config: &Arc<TelegramConfig>,
+    app: &tauri::AppHandle,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let chat_id = msg.chat.id;
+
+    let orchestrator = app
+        .try_state::<AIOrchestrator>()
+        .ok_or("AIOrchestrator not available")?;
+    let llm_service = app
+        .try_state::<LlmService>()
+        .ok_or("LlmService not available")?;
+
+    // 1. Record user message
+    orchestrator
+        .add_message("user".to_string(), text.to_string())
+        .await;
+
+    // Sync user message to desktop UI
+    let _ = app.emit("telegram:chat-sync", TelegramChatSync {
+        role: "user".to_string(),
+        text: text.to_string(),
+        translation: None,
+    });
+
+    // 2. Compose prompt context
+    let prompt_messages = orchestrator
+        .compose_prompt(text, false, None)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut client_messages: Vec<crate::llm::openai::Message> = prompt_messages
+        .into_iter()
+        .map(|m| crate::llm::openai::Message {
+            role: m.role,
+            content: crate::llm::openai::MessageContent::Text(m.content),
+        })
+        .collect();
+
+    // Ensure the latest user turn is in the messages
+    let already_has_user = client_messages
+        .last()
+        .map(|m| m.role == "user")
+        .unwrap_or(false);
+    if !already_has_user {
+        client_messages.push(crate::llm::openai::Message {
+            role: "user".to_string(),
+            content: crate::llm::openai::MessageContent::Text(text.to_string()),
+        });
+    }
+
+    // 3. Stream LLM response (collect fully)
+    let provider = llm_service.provider().await;
+    let mut stream = provider
+        .chat_stream(client_messages, None)
+        .await
+        .map_err(|e| format!("LLM stream error: {}", e))?;
+
+    let mut response = String::new();
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(delta) => response.push_str(&delta),
+            Err(e) => {
+                eprintln!("[Telegram] LLM stream error: {}", e);
+                break;
+            }
+        }
+    }
+
+    if response.is_empty() {
+        bot.send_message(chat_id, "(No response from AI)")
+            .await
+            .ok();
+        return Ok(());
+    }
+
+    // 4. Parse tool calls and translations, clean response
+    let (cleaned, _tool_calls) = parse_tool_call_tags(&response);
+    let (cleaned, translation) = extract_translate_tags(&cleaned);
+    let cleaned = strip_leaked_tags(&cleaned);
+    // Strip remaining control tags that shouldn't appear in Telegram
+    let cleaned = strip_control_tags(&cleaned);
+
+    // 5. Persist assistant message
+    let metadata = translation
+        .as_ref()
+        .map(|t| serde_json::json!({ "translation": t }).to_string());
+    orchestrator
+        .add_message_with_metadata("assistant".to_string(), cleaned.clone(), metadata)
+        .await;
+
+    // Sync assistant message to desktop UI
+    let _ = app.emit("telegram:chat-sync", TelegramChatSync {
+        role: "assistant".to_string(),
+        text: cleaned.clone(),
+        translation: translation.clone(),
+    });
+
+    // 6. Build reply text (include translation if present)
+    let reply_text = if let Some(ref t) = translation {
+        format!("{}\n\n📝 {}", cleaned, t)
+    } else {
+        cleaned.clone()
+    };
+
+    // 7. Send text reply
+    bot.send_message(chat_id, &reply_text).await.ok();
+
+    // 8. Optionally send voice reply
+    if config.send_voice_reply {
+        send_voice_reply(bot, chat_id, &cleaned, app).await;
+    }
+
+    // 9. Handle image generation tags
+    handle_image_tags(bot, chat_id, &response, app).await;
+
+    Ok(())
+}
+
+/// Handle voice messages — download, transcribe via STT, then process as text.
+async fn handle_voice(
+    bot: &Bot,
+    msg: &Message,
+    config: &Arc<TelegramConfig>,
+    _sessions: &Sessions,
+    app: &tauri::AppHandle,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let chat_id = msg.chat.id;
+    let voice = msg.voice().ok_or("No voice data")?;
+
+    let stt_service = match app.try_state::<SttService>() {
+        Some(s) => s,
+        None => {
+            bot.send_message(chat_id, "⚠️ STT service not available.")
+                .await
+                .ok();
+            return Ok(());
+        }
+    };
+
+    // Download voice file from Telegram
+    let file = bot.get_file(&voice.file.id).await?;
+    let mut buf = Vec::new();
+    teloxide::net::Download::download_file(bot, &file.path, &mut buf).await?;
+
+    // Transcribe (Telegram voice messages are OGG/Opus)
+    let audio_source = AudioSource::Encoded {
+        data: buf,
+        format: "ogg".to_string(),
+    };
+    let transcription = match stt_service.transcribe(&audio_source, None).await {
+        Ok(result) => result.text,
+        Err(e) => {
+            eprintln!("[Telegram] STT error: {}", e);
+            bot.send_message(chat_id, "⚠️ Failed to transcribe voice message.")
+                .await
+                .ok();
+            return Ok(());
+        }
+    };
+
+    if transcription.trim().is_empty() {
+        bot.send_message(chat_id, "🔇 (Could not recognize speech)")
+            .await
+            .ok();
+        return Ok(());
+    }
+
+    // Send recognized text back as context
+    bot.send_message(chat_id, format!("🎤 {}", transcription))
+        .await
+        .ok();
+
+    // Process as regular text
+    handle_text(bot, msg, &transcription, config, app).await
+}
+
+/// Handle photo messages — download image, convert to base64, send to LLM with vision.
+async fn handle_photo(
+    bot: &Bot,
+    msg: &Message,
+    config: &Arc<TelegramConfig>,
+    app: &tauri::AppHandle,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let chat_id = msg.chat.id;
+    let photos = msg.photo().ok_or("No photo data")?;
+
+    // Telegram sends multiple sizes — pick the largest one
+    let photo = photos.last().ok_or("Empty photo array")?;
+
+    let orchestrator = app
+        .try_state::<AIOrchestrator>()
+        .ok_or("AIOrchestrator not available")?;
+    let llm_service = app
+        .try_state::<LlmService>()
+        .ok_or("LlmService not available")?;
+
+    // Download photo file
+    let file = bot.get_file(&photo.file.id).await?;
+    let mut buf = Vec::new();
+    teloxide::net::Download::download_file(bot, &file.path, &mut buf).await?;
+
+    // Convert to base64 data URL
+    use base64::Engine as _;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&buf);
+    // Detect mime from file extension or default to jpeg
+    let mime = if file.path.ends_with(".png") {
+        "image/png"
+    } else {
+        "image/jpeg"
+    };
+    let data_url = format!("data:{};base64,{}", mime, b64);
+
+    // Use caption as the user message, or a default prompt
+    let caption = msg
+        .caption()
+        .unwrap_or("The user sent you a photo:")
+        .to_string();
+
+    println!("[Telegram] Photo received, caption: {}", caption);
+
+    // 1. Record user message
+    orchestrator
+        .add_message("user".to_string(), caption.clone())
+        .await;
+
+    // Sync user message to desktop UI
+    let _ = app.emit("telegram:chat-sync", TelegramChatSync {
+        role: "user".to_string(),
+        text: format!("[TG] 📷 {}", caption),
+        translation: None,
+    });
+
+    // 2. Compose prompt context
+    let prompt_messages = orchestrator
+        .compose_prompt(&caption, false, None)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut client_messages: Vec<crate::llm::openai::Message> = prompt_messages
+        .into_iter()
+        .map(|m| crate::llm::openai::Message {
+            role: m.role,
+            content: crate::llm::openai::MessageContent::Text(m.content),
+        })
+        .collect();
+
+    // Replace or append the last user message with multimodal content (text + image)
+    let already_has_user = client_messages
+        .last()
+        .map(|m| m.role == "user")
+        .unwrap_or(false);
+    if already_has_user {
+        // Replace last user message with multimodal version
+        let last = client_messages.last_mut().unwrap();
+        last.content = crate::llm::openai::MessageContent::with_images(
+            caption.clone(),
+            vec![data_url],
+        );
+    } else {
+        client_messages.push(crate::llm::openai::Message {
+            role: "user".to_string(),
+            content: crate::llm::openai::MessageContent::with_images(
+                caption.clone(),
+                vec![data_url],
+            ),
+        });
+    }
+
+    // 3. Stream LLM response
+    let provider = llm_service.provider().await;
+    let mut stream = provider
+        .chat_stream(client_messages, None)
+        .await
+        .map_err(|e| format!("LLM stream error: {}", e))?;
+
+    let mut response = String::new();
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(delta) => response.push_str(&delta),
+            Err(e) => {
+                eprintln!("[Telegram] LLM stream error: {}", e);
+                break;
+            }
+        }
+    }
+
+    if response.is_empty() {
+        bot.send_message(chat_id, "(No response from AI)")
+            .await
+            .ok();
+        return Ok(());
+    }
+
+    // 4. Clean response
+    let (cleaned, _tool_calls) = parse_tool_call_tags(&response);
+    let (cleaned, translation) = extract_translate_tags(&cleaned);
+    let cleaned = strip_leaked_tags(&cleaned);
+    let cleaned = strip_control_tags(&cleaned);
+
+    // 5. Persist
+    let metadata = translation
+        .as_ref()
+        .map(|t| serde_json::json!({ "translation": t }).to_string());
+    orchestrator
+        .add_message_with_metadata("assistant".to_string(), cleaned.clone(), metadata)
+        .await;
+
+    // Sync to desktop
+    let _ = app.emit("telegram:chat-sync", TelegramChatSync {
+        role: "assistant".to_string(),
+        text: cleaned.clone(),
+        translation: translation.clone(),
+    });
+
+    // 6. Reply
+    let reply_text = if let Some(ref t) = translation {
+        format!("{}\n\n📝 {}", cleaned, t)
+    } else {
+        cleaned.clone()
+    };
+    bot.send_message(chat_id, &reply_text).await.ok();
+
+    // 7. Voice reply
+    if config.send_voice_reply {
+        send_voice_reply(bot, chat_id, &cleaned, app).await;
+    }
+
+    Ok(())
+}
+
+/// Synthesize text via TTS and send as a Telegram voice message.
+async fn send_voice_reply(bot: &Bot, chat_id: ChatId, text: &str, app: &tauri::AppHandle) {
+    let tts_service = match app.try_state::<TtsService>() {
+        Some(s) => s,
+        None => return,
+    };
+
+    match tts_service.synthesize_text(text, None).await {
+        Ok(audio_bytes) if !audio_bytes.is_empty() => {
+            let input = InputFile::memory(audio_bytes).file_name("reply.ogg");
+            if let Err(e) = bot.send_voice(chat_id, input).await {
+                eprintln!("[Telegram] Failed to send voice: {}", e);
+            }
+        }
+        Ok(_) => {} // Empty audio, skip
+        Err(e) => {
+            eprintln!("[Telegram] TTS synthesis error: {}", e);
+        }
+    }
+}
+
+/// Check for `[IMAGE_PROMPT:...]` tags in the response and generate/send images.
+async fn handle_image_tags(bot: &Bot, chat_id: ChatId, response: &str, app: &tauri::AppHandle) {
+    let prefix = "[IMAGE_PROMPT:";
+    let mut search = response.as_bytes();
+    let response_bytes = response.as_bytes();
+
+    loop {
+        let offset = response_bytes.len() - search.len();
+        let haystack = &response[offset..];
+        let start = match haystack.find(prefix) {
+            Some(s) => s,
+            None => break,
+        };
+        let rest = &haystack[start + prefix.len()..];
+        let end = match rest.find(']') {
+            Some(e) => e,
+            None => break,
+        };
+        let prompt = rest[..end].trim();
+        // Advance search past this tag
+        search = &response_bytes[offset + start + prefix.len() + end + 1..];
+
+        if prompt.is_empty() {
+            continue;
+        }
+
+        let imagegen = match app.try_state::<ImageGenService>() {
+            Some(s) => s,
+            None => break,
+        };
+
+        match imagegen.generate(prompt.to_string(), None, None).await {
+            Ok(result) => {
+                // result.image_url is a local file path
+                match tokio::fs::read(&result.image_url).await {
+                    Ok(data) => {
+                        let input = InputFile::memory(data).file_name("image.png");
+                        if let Err(e) = bot.send_photo(chat_id, input).await {
+                            eprintln!("[Telegram] Failed to send photo: {}", e);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("[Telegram] Failed to read generated image: {}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("[Telegram] Image generation failed: {}", e);
+                bot.send_message(chat_id, format!("⚠️ Image generation failed: {}", e))
+                    .await
+                    .ok();
+            }
+        }
+    }
+}
+
+// ── Tag parsing helpers (mirrored from commands/chat.rs) ──────────
+
+const TOOL_CALL_TAG_PREFIX: &str = "[TOOL_CALL:";
+const TRANSLATE_TAG_PREFIX: &str = "[TRANSLATE:";
+
+fn parse_tool_call_tags(text: &str) -> (String, Vec<String>) {
+    let mut result = text.to_string();
+    let mut calls = Vec::new();
+
+    while let Some(start) = result.rfind(TOOL_CALL_TAG_PREFIX) {
+        let rest = &result[start..];
+        if let Some(end_bracket) = rest.find(']') {
+            let inner = &rest[TOOL_CALL_TAG_PREFIX.len()..end_bracket];
+            calls.push(inner.to_string());
+            let tag_end = start + end_bracket + 1;
+            result = format!(
+                "{}{}",
+                result[..start].trim_end(),
+                if tag_end < result.len() {
+                    &result[tag_end..]
+                } else {
+                    ""
+                }
+            );
+        } else {
+            break;
+        }
+    }
+    calls.reverse();
+    (result.trim().to_string(), calls)
+}
+
+fn extract_translate_tags(text: &str) -> (String, Option<String>) {
+    let mut translations = Vec::new();
+    let mut result = text.to_string();
+    while let Some(start) = result.find(TRANSLATE_TAG_PREFIX) {
+        if let Some(end_bracket) = result[start..].find(']') {
+            let inner = &result[start + TRANSLATE_TAG_PREFIX.len()..start + end_bracket];
+            let trimmed = inner.trim();
+            if !trimmed.is_empty() {
+                translations.push(trimmed.to_string());
+            }
+            let tag_end = start + end_bracket + 1;
+            result = format!(
+                "{}{}",
+                result[..start].trim_end(),
+                result[tag_end..].trim_start()
+            );
+        } else {
+            let inner = &result[start + TRANSLATE_TAG_PREFIX.len()..];
+            let trimmed = inner.trim();
+            if !trimmed.is_empty() {
+                translations.push(trimmed.to_string());
+            }
+            result = result[..start].trim_end().to_string();
+        }
+    }
+    let translation = if translations.is_empty() {
+        None
+    } else {
+        Some(translations.join(" "))
+    };
+    (result.trim().to_string(), translation)
+}
+
+fn strip_leaked_tags(text: &str) -> String {
+    let mut result = text.to_string();
+    while let Some(start) = result.find("<tool_result>") {
+        if let Some(end) = result[start..].find("</tool_result>") {
+            let tag_end = start + end + "</tool_result>".len();
+            result = format!(
+                "{}{}",
+                result[..start].trim_end(),
+                result[tag_end..].trim_start()
+            );
+        } else {
+            let line_end = result[start..]
+                .find('\n')
+                .map(|i| start + i)
+                .unwrap_or(result.len());
+            result = format!("{}{}", result[..start].trim_end(), &result[line_end..]);
+        }
+    }
+    result.trim().to_string()
+}
+
+/// Strip control tags that shouldn't appear in Telegram messages:
+/// [ACTION:xxx], [EMOTION:xxx], [IMAGE_PROMPT:xxx] (image handled separately)
+fn strip_control_tags(text: &str) -> String {
+    let mut result = text.to_string();
+    // Remove [ACTION:...] tags
+    while let Some(start) = result.find("[ACTION:") {
+        if let Some(end) = result[start..].find(']') {
+            let tag_end = start + end + 1;
+            result = format!(
+                "{}{}",
+                result[..start].trim_end(),
+                result[tag_end..].trim_start()
+            );
+        } else {
+            break;
+        }
+    }
+    // Remove [EMOTION:...] tags
+    while let Some(start) = result.find("[EMOTION:") {
+        if let Some(end) = result[start..].find(']') {
+            let tag_end = start + end + 1;
+            result = format!(
+                "{}{}",
+                result[..start].trim_end(),
+                result[tag_end..].trim_start()
+            );
+        } else {
+            break;
+        }
+    }
+    result.trim().to_string()
+}

--- a/src-tauri/src/telegram/config.rs
+++ b/src-tauri/src/telegram/config.rs
@@ -1,0 +1,51 @@
+//! Telegram Bot configuration — load/save from app data directory.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelegramConfig {
+    /// Whether the Telegram bot is enabled (auto-start on app launch).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Bot token (direct value).
+    #[serde(default)]
+    pub bot_token: Option<String>,
+    /// Or read token from this environment variable.
+    #[serde(default)]
+    pub bot_token_env: Option<String>,
+    /// Chat ID whitelist — only these chats can interact with the bot.
+    /// Empty list = reject all.
+    #[serde(default)]
+    pub allowed_chat_ids: Vec<i64>,
+    /// Whether to also send a voice message alongside text replies (requires TTS).
+    #[serde(default)]
+    pub send_voice_reply: bool,
+}
+
+impl Default for TelegramConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bot_token: None,
+            bot_token_env: Some("TELEGRAM_BOT_TOKEN".to_string()),
+            allowed_chat_ids: Vec::new(),
+            send_voice_reply: false,
+        }
+    }
+}
+
+impl TelegramConfig {
+    /// Resolve the bot token: check direct field first, then env var.
+    pub fn resolve_bot_token(&self) -> Option<String> {
+        crate::config::resolve_api_key(&self.bot_token, &self.bot_token_env)
+    }
+}
+
+pub fn load_config(path: &Path) -> TelegramConfig {
+    crate::config::load_json_config(path, "TELEGRAM")
+}
+
+pub fn save_config(path: &Path, config: &TelegramConfig) -> Result<(), String> {
+    crate::config::save_json_config(path, config, "TELEGRAM")
+}

--- a/src-tauri/src/telegram/mod.rs
+++ b/src-tauri/src/telegram/mod.rs
@@ -1,0 +1,84 @@
+//! Telegram Bot module — lifecycle management and re-exports.
+
+pub mod bot;
+pub mod config;
+
+pub use config::{load_config, save_config, TelegramConfig};
+
+use std::sync::Arc;
+use tokio::sync::{oneshot, RwLock};
+
+/// Managed Tauri state for the Telegram bot service.
+#[derive(Clone)]
+pub struct TelegramService {
+    config: Arc<RwLock<TelegramConfig>>,
+    /// Sender half of the shutdown signal. `Some` = bot is running.
+    shutdown_tx: Arc<RwLock<Option<oneshot::Sender<()>>>>,
+}
+
+impl TelegramService {
+    pub fn new(config: TelegramConfig) -> Self {
+        Self {
+            config: Arc::new(RwLock::new(config)),
+            shutdown_tx: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Whether the bot polling loop is currently running.
+    pub async fn is_running(&self) -> bool {
+        self.shutdown_tx.read().await.is_some()
+    }
+
+    /// Get a snapshot of the current config.
+    pub async fn get_config(&self) -> TelegramConfig {
+        self.config.read().await.clone()
+    }
+
+    /// Update the in-memory config (caller is responsible for persisting to disk).
+    pub async fn update_config(&self, new_config: TelegramConfig) {
+        let mut cfg = self.config.write().await;
+        *cfg = new_config;
+    }
+
+    /// Start the bot polling loop. Returns Err if already running or no token.
+    pub async fn start(&self, app: tauri::AppHandle) -> Result<(), String> {
+        if self.is_running().await {
+            return Err("Telegram bot is already running".to_string());
+        }
+
+        let config = self.config.read().await.clone();
+        let token = config
+            .resolve_bot_token()
+            .ok_or("No bot token configured")?;
+
+        let (tx, rx) = oneshot::channel::<()>();
+        {
+            let mut shutdown = self.shutdown_tx.write().await;
+            *shutdown = Some(tx);
+        }
+
+        let shutdown_flag = self.shutdown_tx.clone();
+
+        tauri::async_runtime::spawn(async move {
+            println!("[Telegram] Bot polling started");
+            bot::run_polling(token, config, app, rx).await;
+            println!("[Telegram] Bot polling stopped");
+            // Clear the shutdown sender so is_running() returns false
+            let mut guard = shutdown_flag.write().await;
+            *guard = None;
+        });
+
+        Ok(())
+    }
+
+    /// Stop the bot polling loop gracefully.
+    pub async fn stop(&self) -> Result<(), String> {
+        let mut shutdown = self.shutdown_tx.write().await;
+        if let Some(tx) = shutdown.take() {
+            let _ = tx.send(());
+            Ok(())
+        } else {
+            Err("Telegram bot is not running".to_string())
+        }
+    }
+}

--- a/src/lib/kokoro-bridge.ts
+++ b/src/lib/kokoro-bridge.ts
@@ -343,6 +343,10 @@ export async function importLive2dZip(zipPath: string): Promise<string> {
     return invoke<string>("import_live2d_zip", { zipPath });
 }
 
+export async function importLive2dFolder(modelJsonPath: string): Promise<string> {
+    return invoke<string>("import_live2d_folder", { modelJsonPath });
+}
+
 export async function listLive2dModels(): Promise<Live2dModelInfo[]> {
     return invoke<Live2dModelInfo[]>("list_live2d_models");
 }
@@ -725,4 +729,50 @@ export async function convertSinging(
 
 export async function onSingingProgress(callback: (event: SingingProgressEvent) => void): Promise<UnlistenFn> {
     return listen<SingingProgressEvent>("singing:progress", (event) => callback(event.payload));
+}
+
+// ── Telegram Bot ──────────────────────────────────
+
+export interface TelegramConfig {
+    enabled: boolean;
+    bot_token?: string;
+    bot_token_env?: string;
+    allowed_chat_ids: number[];
+    send_voice_reply: boolean;
+}
+
+export interface TelegramStatus {
+    running: boolean;
+    enabled: boolean;
+    has_token: boolean;
+}
+
+export async function getTelegramConfig(): Promise<TelegramConfig> {
+    return invoke<TelegramConfig>("get_telegram_config");
+}
+
+export async function saveTelegramConfig(config: TelegramConfig): Promise<void> {
+    return invoke("save_telegram_config", { config });
+}
+
+export async function startTelegramBot(): Promise<void> {
+    return invoke("start_telegram_bot");
+}
+
+export async function stopTelegramBot(): Promise<void> {
+    return invoke("stop_telegram_bot");
+}
+
+export async function getTelegramStatus(): Promise<TelegramStatus> {
+    return invoke<TelegramStatus>("get_telegram_status");
+}
+
+export interface TelegramChatSync {
+    role: string;
+    text: string;
+    translation?: string;
+}
+
+export async function onTelegramChatSync(callback: (data: TelegramChatSync) => void): Promise<UnlistenFn> {
+    return listen<TelegramChatSync>("telegram:chat-sync", (event) => callback(event.payload));
 }

--- a/src/ui/widgets/SettingsPanel.tsx
+++ b/src/ui/widgets/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { clsx } from "clsx";
-import { X, Key, User, Volume2, Package, Image, PersonStanding, Save, Check, Sparkles, Brain, Mic, Music, Eye, Server } from "lucide-react";
+import { X, Key, User, Volume2, Package, Image, PersonStanding, Save, Check, Sparkles, Brain, Mic, Music, Eye, Server, Bot } from "lucide-react";
 import { ModList } from "../mods/ModList";
 import CharacterManager from "./CharacterManager";
 import ImageGenSettings from "./ImageGenSettings";
@@ -14,13 +14,14 @@ import ModelTab from "./settings/ModelTab";
 import BackgroundTab from "./settings/BackgroundTab";
 import VisionTab from "./settings/VisionTab";
 import McpTab from "./settings/McpTab";
+import TelegramTab from "./settings/TelegramTab";
 import { useTranslation } from "react-i18next";
 import { setPersona, setResponseLanguage, setUserLanguage, listTtsProviders, listTtsVoices, getTtsConfig, saveTtsConfig, getImageGenConfig, saveImageGenConfig, getSttConfig, saveSttConfig } from "../../lib/kokoro-bridge";
 import type { ProviderStatus, VoiceProfile, TtsSystemConfig, ImageGenSystemConfig, SttConfig } from "../../lib/kokoro-bridge";
 import type { BackgroundConfig } from "../hooks/useBackgroundSlideshow";
 import type { Live2DDisplayMode } from "../../features/live2d/Live2DViewer";
 
-type TabId = "api" | "persona" | "tts" | "stt" | "sing" | "mods" | "bg" | "model" | "imagegen" | "memory" | "vision" | "mcp";
+type TabId = "api" | "persona" | "tts" | "stt" | "sing" | "mods" | "bg" | "model" | "imagegen" | "memory" | "vision" | "mcp" | "telegram";
 
 export interface BackgroundControls {
     config: BackgroundConfig;
@@ -88,6 +89,7 @@ const tabs: { id: TabId; label: string; icon: typeof Key }[] = [
     { id: "vision", label: "settings.tabs.vision", icon: Eye },
     { id: "mods", label: "settings.tabs.mods", icon: Package },
     { id: "mcp", label: "settings.tabs.mcp", icon: Server },
+    { id: "telegram", label: "Telegram", icon: Bot },
 ];
 
 export default function SettingsPanel({ isOpen, onClose, backgroundControls, displayMode, onDisplayModeChange, customModelPath, onCustomModelChange, sttConfig: sttConfigProp, voiceInterrupt: voiceInterruptProp }: SettingsPanelProps) {
@@ -467,6 +469,9 @@ export default function SettingsPanel({ isOpen, onClose, backgroundControls, dis
                             )}
                             {activeTab === "mcp" && (
                                 <McpTab />
+                            )}
+                            {activeTab === "telegram" && (
+                                <TelegramTab />
                             )}
                         </div>
 

--- a/src/ui/widgets/settings/ModelTab.tsx
+++ b/src/ui/widgets/settings/ModelTab.tsx
@@ -4,9 +4,8 @@ import { useTranslation } from "react-i18next";
 import { FolderOpen, RefreshCw, AlertCircle, Trash2, Check } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { open } from "@tauri-apps/plugin-dialog";
-import { exists } from "@tauri-apps/plugin-fs";
 import { labelClasses } from "../../styles/settings-primitives";
-import { importLive2dZip, listLive2dModels, deleteLive2dModel } from "../../../lib/kokoro-bridge";
+import { importLive2dZip, importLive2dFolder, listLive2dModels, deleteLive2dModel } from "../../../lib/kokoro-bridge";
 import type { Live2dModelInfo } from "../../../lib/kokoro-bridge";
 import type { Live2DDisplayMode } from "../../../features/live2d/Live2DViewer";
 
@@ -67,11 +66,16 @@ export default function ModelTab({
                         setIsImporting(false);
                     }
                 } else {
-                    const fileExists = await exists(selected);
-                    if (fileExists) {
-                        onCustomModelPathChange(selected);
-                    } else {
-                        console.error("Selected file does not exist:", selected);
+                    // .model3.json selected — copy the folder into app data
+                    setIsImporting(true);
+                    try {
+                        const modelPath = await importLive2dFolder(selected);
+                        onCustomModelPathChange(modelPath);
+                        await fetchModels();
+                    } catch (e) {
+                        console.error("Failed to import Live2D folder:", e);
+                    } finally {
+                        setIsImporting(false);
                     }
                 }
             }

--- a/src/ui/widgets/settings/TelegramTab.tsx
+++ b/src/ui/widgets/settings/TelegramTab.tsx
@@ -1,0 +1,287 @@
+import { useState, useEffect, useRef } from "react";
+import { motion } from "framer-motion";
+import { clsx } from "clsx";
+import { Bot, Shield, Volume2, Loader2, Play, Square, RefreshCw } from "lucide-react";
+import {
+    getTelegramConfig, saveTelegramConfig,
+    startTelegramBot, stopTelegramBot, getTelegramStatus,
+} from "../../../lib/kokoro-bridge";
+import type { TelegramConfig, TelegramStatus } from "../../../lib/kokoro-bridge";
+import { inputClasses, labelClasses } from "../../styles/settings-primitives";
+
+export default function TelegramTab() {
+    const [config, setConfig] = useState<TelegramConfig | null>(null);
+    const [status, setStatus] = useState<TelegramStatus | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [dirty, setDirty] = useState(false);
+    const [chatIdInput, setChatIdInput] = useState("");
+    const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+    useEffect(() => {
+        loadAll();
+        // Poll status every 5s
+        pollRef.current = setInterval(() => {
+            getTelegramStatus().then(setStatus).catch(() => {});
+        }, 5000);
+        return () => {
+            if (pollRef.current) clearInterval(pollRef.current);
+        };
+    }, []);
+
+    const loadAll = async () => {
+        try {
+            const [cfg, st] = await Promise.all([getTelegramConfig(), getTelegramStatus()]);
+            setConfig(cfg);
+            setStatus(st);
+        } catch (e) {
+            console.error("[TelegramTab] Failed to load:", e);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const update = (patch: Partial<TelegramConfig>) => {
+        if (!config) return;
+        setConfig({ ...config, ...patch });
+        setDirty(true);
+    };
+
+    const handleSave = async () => {
+        if (!config) return;
+        try {
+            await saveTelegramConfig(config);
+            setDirty(false);
+        } catch (e) {
+            console.error("[TelegramTab] Failed to save:", e);
+        }
+    };
+
+    const handleStart = async () => {
+        try {
+            // Save first if dirty
+            if (dirty && config) {
+                await saveTelegramConfig(config);
+                setDirty(false);
+            }
+            await startTelegramBot();
+            const st = await getTelegramStatus();
+            setStatus(st);
+        } catch (e) {
+            console.error("[TelegramTab] Start failed:", e);
+        }
+    };
+
+    const handleStop = async () => {
+        try {
+            await stopTelegramBot();
+            const st = await getTelegramStatus();
+            setStatus(st);
+        } catch (e) {
+            console.error("[TelegramTab] Stop failed:", e);
+        }
+    };
+
+    const addChatId = () => {
+        const id = parseInt(chatIdInput.trim(), 10);
+        if (isNaN(id) || !config) return;
+        if (config.allowed_chat_ids.includes(id)) return;
+        update({ allowed_chat_ids: [...config.allowed_chat_ids, id] });
+        setChatIdInput("");
+    };
+
+    const removeChatId = (id: number) => {
+        if (!config) return;
+        update({ allowed_chat_ids: config.allowed_chat_ids.filter(c => c !== id) });
+    };
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center py-12">
+                <Loader2 size={20} className="animate-spin text-[var(--color-text-muted)]" />
+            </div>
+        );
+    }
+
+    if (!config) return null;
+
+    const isRunning = status?.running ?? false;
+
+    return (
+        <div className="space-y-6">
+            {/* Status & Controls */}
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                    <Bot size={16} strokeWidth={1.5} className="text-[var(--color-accent)]" />
+                    <div>
+                        <div className="text-sm font-heading font-semibold">Telegram Bot</div>
+                        <div className="text-xs text-[var(--color-text-muted)]">
+                            {isRunning ? "Running" : "Stopped"}
+                        </div>
+                    </div>
+                    <div className={clsx(
+                        "w-2 h-2 rounded-full",
+                        isRunning ? "bg-green-400" : "bg-[var(--color-text-muted)]"
+                    )} />
+                </div>
+                <div className="flex items-center gap-2">
+                    {isRunning ? (
+                        <motion.button
+                            whileTap={{ scale: 0.95 }}
+                            onClick={handleStop}
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-heading
+                                bg-red-500/20 text-red-400 border border-red-500/30 hover:bg-red-500/30 transition-colors"
+                        >
+                            <Square size={12} /> Stop
+                        </motion.button>
+                    ) : (
+                        <motion.button
+                            whileTap={{ scale: 0.95 }}
+                            onClick={handleStart}
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-heading
+                                bg-[var(--color-accent)]/20 text-[var(--color-accent)] border border-[var(--color-accent)]/30
+                                hover:bg-[var(--color-accent)]/30 transition-colors"
+                        >
+                            <Play size={12} /> Start
+                        </motion.button>
+                    )}
+                    <motion.button
+                        whileTap={{ scale: 0.95 }}
+                        onClick={loadAll}
+                        className="p-1.5 rounded-md text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
+                    >
+                        <RefreshCw size={14} />
+                    </motion.button>
+                </div>
+            </div>
+
+            {/* Enable on startup */}
+            <div className="flex items-center justify-between">
+                <div className="text-sm text-[var(--color-text-secondary)]">Auto-start on launch</div>
+                <motion.button
+                    whileTap={{ scale: 0.95 }}
+                    onClick={() => update({ enabled: !config.enabled })}
+                    className={clsx(
+                        "w-12 h-6 rounded-full relative transition-colors duration-200",
+                        config.enabled
+                            ? "bg-[var(--color-accent)]"
+                            : "bg-[var(--color-bg-surface)] border border-[var(--color-border)]"
+                    )}
+                >
+                    <motion.div
+                        animate={{ x: config.enabled ? 24 : 2 }}
+                        transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                        className={clsx(
+                            "w-5 h-5 rounded-full absolute top-0.5",
+                            config.enabled ? "bg-black" : "bg-[var(--color-text-muted)]"
+                        )}
+                    />
+                </motion.button>
+            </div>
+
+            {/* Bot Token */}
+            <div>
+                <label className={labelClasses}>Bot Token</label>
+                <input
+                    type="password"
+                    value={config.bot_token ?? ""}
+                    onChange={e => update({ bot_token: e.target.value || undefined })}
+                    placeholder="123456:ABC-DEF..."
+                    className={inputClasses}
+                />
+                <div className="text-xs text-[var(--color-text-muted)] mt-1">
+                    Get from @BotFather on Telegram. Or set env var: {config.bot_token_env ?? "TELEGRAM_BOT_TOKEN"}
+                </div>
+            </div>
+
+            {/* Allowed Chat IDs */}
+            <div>
+                <label className={labelClasses}>
+                    <Shield size={12} className="inline mr-1" />
+                    Allowed Chat IDs
+                </label>
+                <div className="text-xs text-[var(--color-text-muted)] mb-2">
+                    Only these chat IDs can interact with the bot. Empty = reject all.
+                </div>
+                <div className="flex gap-2 mb-2">
+                    <input
+                        type="text"
+                        value={chatIdInput}
+                        onChange={e => setChatIdInput(e.target.value)}
+                        onKeyDown={e => e.key === "Enter" && addChatId()}
+                        placeholder="Chat ID (number)"
+                        className={clsx(inputClasses, "flex-1")}
+                    />
+                    <motion.button
+                        whileTap={{ scale: 0.95 }}
+                        onClick={addChatId}
+                        className="px-3 py-2 rounded-md text-xs font-heading
+                            bg-[var(--color-bg-surface)] border border-[var(--color-border)]
+                            hover:border-[var(--color-accent)] transition-colors"
+                    >
+                        Add
+                    </motion.button>
+                </div>
+                {config.allowed_chat_ids.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                        {config.allowed_chat_ids.map(id => (
+                            <span
+                                key={id}
+                                className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs
+                                    bg-[var(--color-bg-surface)] border border-[var(--color-border)]"
+                            >
+                                {id}
+                                <button
+                                    onClick={() => removeChatId(id)}
+                                    className="text-[var(--color-text-muted)] hover:text-red-400 transition-colors ml-1"
+                                >
+                                    ×
+                                </button>
+                            </span>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            {/* Voice Reply */}
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                    <Volume2 size={14} className="text-[var(--color-text-muted)]" />
+                    <div className="text-sm text-[var(--color-text-secondary)]">Send voice replies (TTS)</div>
+                </div>
+                <motion.button
+                    whileTap={{ scale: 0.95 }}
+                    onClick={() => update({ send_voice_reply: !config.send_voice_reply })}
+                    className={clsx(
+                        "w-12 h-6 rounded-full relative transition-colors duration-200",
+                        config.send_voice_reply
+                            ? "bg-[var(--color-accent)]"
+                            : "bg-[var(--color-bg-surface)] border border-[var(--color-border)]"
+                    )}
+                >
+                    <motion.div
+                        animate={{ x: config.send_voice_reply ? 24 : 2 }}
+                        transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                        className={clsx(
+                            "w-5 h-5 rounded-full absolute top-0.5",
+                            config.send_voice_reply ? "bg-black" : "bg-[var(--color-text-muted)]"
+                        )}
+                    />
+                </motion.button>
+            </div>
+
+            {/* Save Button */}
+            {dirty && (
+                <motion.button
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    whileTap={{ scale: 0.97 }}
+                    onClick={handleSave}
+                    className="w-full py-2.5 rounded-md text-sm font-heading font-semibold
+                        bg-[var(--color-accent)] text-black hover:brightness-110 transition-all"
+                >
+                    Save
+                </motion.button>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- Add Telegram Bot integration via teloxide long-polling, bridging to existing LLM/TTS/STT/ImageGen pipeline
- Support text, voice, and photo messages with chat ID whitelist access control
- Bot commands: /start, /new, /continue, /status
- Desktop chat UI syncs Telegram messages in real-time
- Settings panel with token config, whitelist management, and start/stop controls
- Add Live2D folder import functionality

## Test plan
- [x] `cargo check` passes
- [x] `npx tsc --noEmit` passes
- [x] Manual test: configure bot token → start → send /start → receive reply
- [x] Manual test: text messages get AI responses
- [ ] Manual test: voice messages transcribed and replied
- [ ] Manual test: photo messages with vision LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)