### PR TITLE
build: add Linux Nix flake support for development and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ npm run tauri dev
 npm run tauri build
 ```
 
+### 方式三：使用 Nix / Flakes
+
+如果你在 NixOS 或其他启用了 Flakes 的 Linux 环境中开发/运行，可以直接使用仓库内置的 flake。
+
+```bash
+nix develop
+```
+
+NixOS/Home Manager 中声明式安装，或 `nix build` / `nix run` 的用法见 [docs/nix.md](docs/nix.md)。
+
 ## 🤝 参与贡献 (Contributing)
  
 **Kokoro Engine** 极其欢迎社区的贡献！

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -1,0 +1,81 @@
+# Nix
+
+## 启用 Flakes
+
+NixOS:
+
+```nix
+{
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+}
+```
+
+应用配置：
+
+```bash
+sudo nixos-rebuild switch
+```
+
+非 NixOS 临时启用：
+
+```bash
+nix --extra-experimental-features "nix-command flakes" develop
+```
+
+## 开发
+
+```bash
+nix develop
+npm install
+npm run tauri dev
+```
+
+## 构建
+
+```bash
+nix build .#default
+./result/bin/tauri-appkokoro-engine
+```
+
+也可以：
+
+```bash
+nix run .#default
+```
+
+## NixOS Flake 安装
+
+先把仓库加到你的系统 flake 输入里：
+
+```nix
+{
+  inputs.kokoro-engine.url = "github:chyinan/Kokoro-Engine";
+}
+```
+
+然后在 `configuration.nix` 对应模块里安装：
+
+```nix
+{ pkgs, inputs, ... }:
+{
+  environment.systemPackages = [
+    inputs.kokoro-engine.packages.${pkgs.system}.default
+  ];
+}
+```
+
+## Home Manager 安装
+
+```nix
+{ pkgs, inputs, ... }:
+{
+  home.packages = [
+    inputs.kokoro-engine.packages.${pkgs.system}.default
+  ];
+}
+```
+
+## 说明
+
+- 当前 flake 主要支持 Linux。
+- 包里已经带上 WebKitGTK、glib-networking、GStreamer 和 ONNX Runtime 相关运行时设置。

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,10 @@
       nixpkgs,
       flake-utils,
     }:
-    flake-utils.lib.eachDefaultSystem (
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-linux"
+    ] (
       system:
       let
         pkgs = import nixpkgs { inherit system; };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,138 @@
+{
+  description = "Kokoro Engine Nix development shell and package";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        lib = pkgs.lib;
+
+        pname = "kokoro-engine";
+        version = "0.1.3";
+
+        src = lib.cleanSource ./.;
+
+        runtimeLibraries = with pkgs; [
+          atk
+          cairo
+          gdk-pixbuf
+          glib
+          glib-networking
+          gsettings-desktop-schemas
+          gst_all_1.gst-plugins-base
+          gst_all_1.gst-plugins-good
+          gst_all_1.gstreamer
+          gtk3
+          libayatana-appindicator
+          librsvg
+          libsoup_3
+          onnxruntime
+          openssl
+          pango
+          webkitgtk_4_1
+        ];
+
+        app = pkgs.rustPlatform.buildRustPackage {
+          inherit pname version src;
+
+          cargoLock = {
+            lockFile = ./src-tauri/Cargo.lock;
+          };
+
+          cargoRoot = "src-tauri";
+          buildAndTestSubdir = "src-tauri";
+
+          npmDeps = pkgs.fetchNpmDeps {
+            name = "${pname}-${version}-npm-deps";
+            inherit src;
+            hash = "sha256-LdtyukW15us0UBRXT/MIhS7IacxlgEJm1HNo65TKdSM=";
+          };
+
+          nativeBuildInputs = with pkgs; [
+            cargo-tauri.hook
+            nodejs
+            npmHooks.npmConfigHook
+            pkg-config
+          ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+            wrapGAppsHook4
+          ];
+
+          buildInputs = runtimeLibraries;
+
+          ORT_LIB_LOCATION = "${pkgs.onnxruntime}/lib";
+          ORT_PREFER_DYNAMIC_LINK = "1";
+          ORT_SKIP_DOWNLOAD = "1";
+
+          postInstall = ''
+            for bin in "$out"/bin/*; do
+              wrapProgram "$bin" \
+                --set GIO_MODULE_DIR ${pkgs.glib-networking}/lib/gio/modules \
+                --prefix GIO_EXTRA_MODULES : ${pkgs.glib-networking}/lib/gio/modules \
+                --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${pkgs.gst_all_1.gstreamer}/lib/gstreamer-1.0 \
+                --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0 \
+                --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0 \
+                --set GST_PLUGIN_SCANNER ${pkgs.gst_all_1.gstreamer.out}/libexec/gstreamer-1.0/gst-plugin-scanner \
+                --prefix XDG_DATA_DIRS : ${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name} \
+                --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeLibraries}
+            done
+          '';
+
+          meta = with lib; {
+            description = "Desktop virtual character interaction engine built with Tauri";
+            homepage = "https://github.com/chyinan/Kokoro-Engine";
+            platforms = platforms.linux;
+            mainProgram = "tauri-appkokoro-engine";
+          };
+        };
+      in
+      {
+        packages.default = app;
+
+        apps.default = {
+          type = "app";
+          program = "${app}/bin/${app.meta.mainProgram}";
+        };
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            cargo
+            cargo-tauri
+            nodejs
+            pkg-config
+            rust-analyzer
+            rustc
+            rustfmt
+          ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+            wrapGAppsHook4
+          ];
+
+          buildInputs = runtimeLibraries;
+
+          RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+
+          shellHook = ''
+            export XDG_DATA_DIRS="$GSETTINGS_SCHEMAS_PATH''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+            export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules"
+            export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules''${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}"
+            export GST_PLUGIN_SYSTEM_PATH_1_0="${pkgs.gst_all_1.gstreamer}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0''${GST_PLUGIN_SYSTEM_PATH_1_0:+:$GST_PLUGIN_SYSTEM_PATH_1_0}"
+            export GST_PLUGIN_SCANNER="${pkgs.gst_all_1.gstreamer.out}/libexec/gstreamer-1.0/gst-plugin-scanner"
+            export ORT_LIB_LOCATION="${pkgs.onnxruntime}/lib"
+            export ORT_PREFER_DYNAMIC_LINK=1
+            export ORT_SKIP_DOWNLOAD=1
+            export LD_LIBRARY_PATH=${lib.makeLibraryPath runtimeLibraries}:$LD_LIBRARY_PATH
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -24,12 +24,14 @@
         src = lib.cleanSource ./.;
 
         runtimeLibraries = with pkgs; [
+          alsa-lib
           atk
           cairo
           gdk-pixbuf
           glib
           glib-networking
           gsettings-desktop-schemas
+          gst_all_1.gst-plugins-bad
           gst_all_1.gst-plugins-base
           gst_all_1.gst-plugins-good
           gst_all_1.gstreamer
@@ -79,6 +81,7 @@
               wrapProgram "$bin" \
                 --set GIO_MODULE_DIR ${pkgs.glib-networking}/lib/gio/modules \
                 --prefix GIO_EXTRA_MODULES : ${pkgs.glib-networking}/lib/gio/modules \
+                --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${pkgs.gst_all_1.gst-plugins-bad}/lib/gstreamer-1.0 \
                 --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${pkgs.gst_all_1.gstreamer}/lib/gstreamer-1.0 \
                 --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0 \
                 --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0 \
@@ -102,6 +105,7 @@
         apps.default = {
           type = "app";
           program = "${app}/bin/${app.meta.mainProgram}";
+          meta = app.meta;
         };
 
         devShells.default = pkgs.mkShell {
@@ -125,7 +129,7 @@
             export XDG_DATA_DIRS="$GSETTINGS_SCHEMAS_PATH''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
             export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules"
             export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules''${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}"
-            export GST_PLUGIN_SYSTEM_PATH_1_0="${pkgs.gst_all_1.gstreamer}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0''${GST_PLUGIN_SYSTEM_PATH_1_0:+:$GST_PLUGIN_SYSTEM_PATH_1_0}"
+            export GST_PLUGIN_SYSTEM_PATH_1_0="${pkgs.gst_all_1.gst-plugins-bad}/lib/gstreamer-1.0:${pkgs.gst_all_1.gstreamer}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0''${GST_PLUGIN_SYSTEM_PATH_1_0:+:$GST_PLUGIN_SYSTEM_PATH_1_0}"
             export GST_PLUGIN_SCANNER="${pkgs.gst_all_1.gstreamer.out}/libexec/gstreamer-1.0/gst-plugin-scanner"
             export ORT_LIB_LOCATION="${pkgs.onnxruntime}/lib"
             export ORT_PREFER_DYNAMIC_LINK=1


### PR DESCRIPTION
## Summary / 概述

Add Linux-focused Nix flake support for Kokoro Engine, including a development shell, packaged build output, wrapped runtime dependencies, and documentation for development and installation.

为 Kokoro Engine 增加面向 Linux 的 Nix flake 支持，包括开发环境、打包构建、运行时依赖配置，以及本地开发和安装文档。

## Changes / 变更内容

- Added `flake.nix` with Linux-only package outputs for `x86_64-linux` and `aarch64-linux`
- Added a Nix development shell with Rust, Node, Tauri, and pkg-config tooling
- Added runtime libraries required for Linux Tauri execution, including WebKitGTK, GStreamer, glib-networking, ONNX Runtime, and ALSA
- Wrapped built binaries with the required runtime environment variables (`LD_LIBRARY_PATH`, GIO modules, GStreamer plugin paths, etc.)
- Added `flake.lock` for reproducible dependency resolution
- Added Nix usage and installation documentation in `docs/nix.md`
- Added README documentation linking to the Nix workflow

## Type / 类型

- [ ] `feat` — New feature / 新功能
- [ ] `fix` — Bug fix / Bug 修复
- [ ] `refactor` — Code refactoring / 代码重构
- [x] `docs` — Documentation / 文档
- [ ] `style` — UI/CSS changes / 界面样式
- [ ] `test` — Tests / 测试
- [x] `chore` — Build/tooling / 构建工具

## Testing / 测试

<!-- How was this tested? / 如何测试的？ -->

- [ ] `npm run tauri dev` runs without errors
- [ ] `npx tsc --noEmit` passes
- [ ] `cargo check` passes
- [x] Manually tested the feature

Manual testing included:
- `nix develop`
- `nix build .#default`
- `nix run .#default`
- verification that the flake only evaluates Linux systems

## Screenshots / 截图

N/A

## Related Issues / 相关 Issue

N/A
