### PR TITLE
fix: restore pet window resize support on Niri

### DIFF
--- a/src-tauri/capabilities/pet.json
+++ b/src-tauri/capabilities/pet.json
@@ -8,9 +8,11 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "core:window:allow-start-resize-dragging",
     "core:window:allow-outer-position",
     "core:window:allow-set-position",
     "core:window:allow-set-size",
+    "core:window:allow-set-resizable",
     "core:window:allow-inner-size",
     "core:event:allow-emit",
     "core:event:allow-emit-to",

--- a/src/features/live2d/Live2DViewer.tsx
+++ b/src/features/live2d/Live2DViewer.tsx
@@ -30,6 +30,7 @@ export interface Live2DViewerHandle {
     playMotion: (group: string, index?: number) => void;
     getModel: () => Live2DModel | null;
     getController: () => Live2DController | undefined;
+    fitToView: () => void;
 }
 
 export type Live2DDisplayMode = "full" | "upper" | "upper-thigh";
@@ -51,6 +52,8 @@ export interface Live2DViewerProps {
     gazeTracking?: boolean;
     /** Fixed canvas size (disables auto-resize), useful for pet window */
     fixedSize?: { width: number; height: number };
+    /** Optional user scale multiplier applied on top of auto-fit */
+    scaleMultiplier?: number;
     /** Callback when model is loaded and sized */
     onModelLoaded?: (bounds: { width: number; height: number }) => void;
 }
@@ -58,11 +61,13 @@ export interface Live2DViewerProps {
 // ── Component ──────────────────────────────────────
 
 const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
-    ({ modelUrl, controller, onHitAreaTap, className, backgroundAlpha = 0, displayMode = "full", gazeTracking = true, fixedSize, onModelLoaded }, ref) => {
+    ({ modelUrl, controller, onHitAreaTap, className, backgroundAlpha = 0, displayMode = "full", gazeTracking = true, fixedSize, scaleMultiplier = 1, onModelLoaded }, ref) => {
         const containerRef = useRef<HTMLDivElement>(null);
         const appRef = useRef<PIXI.Application | null>(null);
         const modelRef = useRef<Live2DModel | null>(null);
         const gazeTrackingRef = useRef(gazeTracking);
+        const fitModelRef = useRef<(() => void) | null>(null);
+        const scaleMultiplierRef = useRef(scaleMultiplier);
 
         // Internal controller if none provided
         const internalControllerRef = useRef<Live2DController | null>(null);
@@ -103,6 +108,9 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
                 },
                 getController() {
                     return ctrl || undefined;
+                },
+                fitToView() {
+                    fitModelRef.current?.();
                 }
             };
         });
@@ -153,6 +161,11 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
         useEffect(() => {
             gazeTrackingRef.current = gazeTracking;
         }, [gazeTracking]);
+
+        useEffect(() => {
+            scaleMultiplierRef.current = scaleMultiplier;
+            fitModelRef.current?.();
+        }, [scaleMultiplier]);
 
         // Gaze tracking: model eyes follow cursor
         const handlePointerMove = useCallback((e: PIXI.InteractionEvent) => {
@@ -209,63 +222,47 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
                     const originalWidth = model.width;
                     const originalHeight = model.height;
 
-                    // Calculate initial scale based on fixedSize or container
-                    let initialScale: number;
-                    if (fixedSize) {
-                        // Calculate scale to fit the fixed size
-                        const scaleX = fixedSize.width / originalWidth;
-                        const scaleY = fixedSize.height / originalHeight;
-                        initialScale = Math.min(scaleX, scaleY) * 0.9; // 0.9 for some padding
-                    } else {
-                        // Use container size
-                        const scaleX = app.screen.width / originalWidth;
-                        const scaleY = app.screen.height / originalHeight;
-                        initialScale = Math.min(scaleX, scaleY);
-                    }
-
-                    // Apply initial scale
-                    model.scale.set(initialScale);
-
                     // Scale model to fit container based on display mode
                     const fitModel = () => {
-                        // If fixedSize is provided, keep the initial scale and just center
-                        if (fixedSize) {
-                            // Model scale is already set, just center it
-                            model.x = (app.screen.width - model.width) / 2;
-                            model.y = (app.screen.height - model.height) / 2;
-                            return;
-                        }
-
                         const scaleX = app.screen.width / originalWidth;
                         const scaleY = app.screen.height / originalHeight;
 
                         // Mode-specific scaling
                         let scale: number;
 
+                        if (fixedSize) {
+                            // Pet window uses a bottom-aligned, height-first fit.
+                            // Start by nearly filling the available height, then clamp to width if needed.
+                            const baseScale = Math.min(scaleY * 0.98, scaleX * 1.15);
+                            scale = baseScale * scaleMultiplierRef.current;
+                            model.scale.set(scale);
+                            model.x = (app.screen.width - model.width) / 2;
+                            model.y = app.screen.height - model.height;
+                            return;
+                        }
+
                         switch (displayMode) {
                             case "upper":
-                                // Modest zoom, anchor top of model near top of screen
-                                scale = Math.min(scaleX, scaleY) * 1.5;
+                                scale = Math.min(scaleX, scaleY) * 1.5 * scaleMultiplierRef.current;
                                 model.scale.set(scale);
                                 model.x = (app.screen.width - model.width) / 2;
-                                // Place model so head is visible: top-align with small margin
                                 model.y = app.screen.height * 0.05;
                                 break;
                             case "upper-thigh":
-                                // Slight zoom, show most of the body
-                                scale = Math.min(scaleX, scaleY) * 1.25;
+                                scale = Math.min(scaleX, scaleY) * 1.25 * scaleMultiplierRef.current;
                                 model.scale.set(scale);
                                 model.x = (app.screen.width - model.width) / 2;
                                 model.y = app.screen.height * 0.03;
                                 break;
-                            default: // "full"
-                                scale = Math.min(scaleX, scaleY);
+                            default:
+                                scale = Math.min(scaleX, scaleY) * scaleMultiplierRef.current;
                                 model.scale.set(scale);
                                 model.x = (app.screen.width - model.width) / 2;
                                 model.y = (app.screen.height - model.height) / 2;
                                 break;
                         }
                     };
+                    fitModelRef.current = fitModel;
                     fitModel();
 
                     // Notify parent of model size (for pet window auto-sizing)
@@ -287,15 +284,7 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
                     }
 
                     // Handle resize (only if not fixed size)
-                    if (!fixedSize) {
-                        app.renderer.on('resize', fitModel);
-                    } else {
-                        // For fixed size mode, still listen to resize to re-center the model
-                        app.renderer.on('resize', () => {
-                            model.x = (app.screen.width - model.width) / 2;
-                            model.y = (app.screen.height - model.height) / 2;
-                        });
-                    }
+                    app.renderer.on('resize', fitModel);
 
                     // Ensure model is interactive
                     (model as any).interactive = true;
@@ -411,6 +400,7 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
                     model.destroy();
                     modelRef.current = null;
                 }
+                fitModelRef.current = null;
 
                 app.stage.off("pointermove", handlePointerMove);
                 try {
@@ -421,6 +411,15 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
                 appRef.current = null;
             };
         }, [modelUrl, backgroundAlpha, displayMode, handlePointerMove, onHitAreaTap, getActiveController]);
+
+        useEffect(() => {
+            if (!fixedSize) return;
+
+            const app = appRef.current;
+            if (!app) return;
+
+            app.renderer.resize(fixedSize.width, fixedSize.height);
+        }, [fixedSize?.height, fixedSize?.width]);
 
         return (
             <div

--- a/src/windows/PetWindow.tsx
+++ b/src/windows/PetWindow.tsx
@@ -19,10 +19,13 @@ interface PetConfig {
     model_url: string | null;
     window_width: number;
     window_height: number;
-    model_scale: number;
+    model_scale?: number;
 }
 
+type ResizeDirection = "East" | "North" | "NorthEast" | "NorthWest" | "South" | "SouthEast" | "SouthWest" | "West";
+
 export default function PetWindow() {
+    const currentWindow = getCurrentWindow();
     // Read model from localStorage and sync when main window changes it
     const getModelUrl = () => {
         const saved = localStorage.getItem("kokoro_custom_model_path");
@@ -54,44 +57,30 @@ export default function PetWindow() {
     const isDragModeRef = useRef(false);
     const isResizeModeRef = useRef(false);
     const rightClickStartRef = useRef<{ x: number; y: number } | null>(null);
-    const savedScaleRef = useRef<number>(0); // restored scale to apply after model loads
+    const userScaleMultiplierRef = useRef(1);
     const [configLoaded, setConfigLoaded] = useState(false);
+    const [scaleMultiplier, setScaleMultiplier] = useState(1);
     const { isStreaming, sendMessage } = usePetChat();
 
-    // On mount: restore saved window size and model scale from config
-    // Must complete before Live2DViewer renders to avoid race condition with handleModelLoaded
+    // On mount: restore saved window size from config
     useEffect(() => {
         invoke<PetConfig>("get_pet_config").then(cfg => {
             if (cfg.window_width > 0 && cfg.window_height > 0) {
                 setCanvasSize({ width: cfg.window_width, height: cfg.window_height });
                 invoke("resize_pet_window", { width: cfg.window_width, height: cfg.window_height }).catch(console.error);
             }
-            if (cfg.model_scale > 0) {
-                savedScaleRef.current = cfg.model_scale;
-            }
+            const savedMultiplier = cfg.model_scale && cfg.model_scale > 0 ? cfg.model_scale : 1;
+            userScaleMultiplierRef.current = savedMultiplier;
+            setScaleMultiplier(savedMultiplier);
             setConfigLoaded(true);
         }).catch(() => {
             setConfigLoaded(true); // 即使失败也要允许渲染
         });
     }, []);
 
-    // Handle model loaded - restore saved size/scale or auto-fit
+    // Handle model loaded - auto-fit the first window size to model bounds
     const handleModelLoaded = useCallback(async (bounds: { width: number; height: number }) => {
         console.log("[PetWindow] Model loaded with natural bounds:", bounds);
-
-        // If we have a saved scale, apply it and skip auto-resize
-        if (savedScaleRef.current > 0) {
-            const model = viewerRef.current?.getModel();
-            if (model) {
-                model.scale.set(savedScaleRef.current);
-                const canvas = document.querySelector('canvas');
-                if (canvas) {
-                    model.x = (canvas.width - model.width) / 2;
-                    model.y = (canvas.height - model.height) / 2;
-                }
-            }
-            return;
-        }
 
         // First launch: auto-fit to model bounds
         const padding = 30;
@@ -134,18 +123,14 @@ export default function PetWindow() {
         isResizeModeRef.current = isResizeMode;
     }, [isDragMode, isResizeMode]);
 
-    // Resize mode: drag edges to resize window + Ctrl+Wheel to scale model
+    // Resize mode: drag edges to resize window + Ctrl+Wheel to fine-tune model scale
     useEffect(() => {
         if (!isResizeMode) return;
-
-        let resizeEdge: 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw' | null = null;
-        let resizeStartPos: { x: number; y: number } | null = null;
-        let windowStartSize: { width: number; height: number } | null = null;
-        let windowStartPos: { x: number; y: number } | null = null;
+        currentWindow.setResizable(true).catch(console.error);
 
         const EDGE_SIZE = 10; // px from edge to detect resize
 
-        const detectEdge = (e: MouseEvent): typeof resizeEdge => {
+        const detectEdge = (e: MouseEvent): 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw' | null => {
             const rect = document.body.getBoundingClientRect();
             const x = e.clientX;
             const y = e.clientY;
@@ -166,7 +151,7 @@ export default function PetWindow() {
             return null;
         };
 
-        const getCursor = (edge: typeof resizeEdge): string => {
+        const getCursor = (edge: ReturnType<typeof detectEdge>): string => {
             if (!edge) return 'default';
             const cursors = {
                 n: 'ns-resize',
@@ -181,114 +166,55 @@ export default function PetWindow() {
             return cursors[edge];
         };
 
-        const recenterModel = () => {
-            const model = viewerRef.current?.getModel();
-            if (model) {
-                const canvas = document.querySelector('canvas');
-                if (canvas) {
-                    model.x = (canvas.width - model.width) / 2;
-                    model.y = (canvas.height - model.height) / 2;
-                }
-            }
+        const getResizeDirection = (edge: NonNullable<ReturnType<typeof detectEdge>>): ResizeDirection => {
+            const directions: Record<NonNullable<ReturnType<typeof detectEdge>>, ResizeDirection> = {
+                n: "North",
+                s: "South",
+                e: "East",
+                w: "West",
+                ne: "NorthEast",
+                nw: "NorthWest",
+                se: "SouthEast",
+                sw: "SouthWest",
+            };
+            return directions[edge];
         };
 
-        // Ctrl + Wheel to scale model
-        const handleWheel = (e: WheelEvent) => {
-            if (e.ctrlKey) {
-                e.preventDefault();
-
-                const model = viewerRef.current?.getModel();
-                if (!model) return;
-
-                const delta = e.deltaY > 0 ? -0.02 : 0.02;
-                const currentScale = model.scale.x;
-                const newScale = Math.max(0.1, Math.min(3.0, currentScale + delta));
-
-                model.scale.set(newScale);
-                recenterModel();
-
-                // Persist scale
-                invoke<PetConfig>("get_pet_config").then(cfg => {
-                    invoke("save_pet_config", { config: { ...cfg, model_scale: newScale } }).catch(console.error);
-                }).catch(console.error);
-            }
-        };
-
-        const handleMouseMove = async (e: MouseEvent) => {
-            if (resizeEdge && resizeStartPos && windowStartSize && windowStartPos) {
-                // Resizing
-                const dx = e.screenX - resizeStartPos.x;
-                const dy = e.screenY - resizeStartPos.y;
-
-                let newWidth = windowStartSize.width;
-                let newHeight = windowStartSize.height;
-                let newX = windowStartPos.x;
-                let newY = windowStartPos.y;
-
-                if (resizeEdge.includes('e')) newWidth = Math.max(200, windowStartSize.width + dx);
-                if (resizeEdge.includes('w')) {
-                    newWidth = Math.max(200, windowStartSize.width - dx);
-                    newX = windowStartPos.x + dx;
-                }
-                if (resizeEdge.includes('s')) newHeight = Math.max(200, windowStartSize.height + dy);
-                if (resizeEdge.includes('n')) {
-                    newHeight = Math.max(200, windowStartSize.height - dy);
-                    newY = windowStartPos.y + dy;
-                }
-
-                try {
-                    await invoke("resize_pet_window", { width: newWidth, height: newHeight });
-                    if (newX !== windowStartPos.x || newY !== windowStartPos.y) {
-                        await getCurrentWindow().setPosition(new PhysicalPosition(newX, newY));
-                    }
-                    setCanvasSize({ width: newWidth, height: newHeight });
-
-                    // Re-center model after resize
-                    setTimeout(recenterModel, 50);
-                } catch (e) {
-                    console.error("[PetWindow] Failed to resize:", e);
-                }
-            } else {
-                // Hovering - update cursor
-                const edge = detectEdge(e);
-                document.body.style.cursor = getCursor(edge);
-            }
+        const handleMouseMove = (e: MouseEvent) => {
+            const edge = detectEdge(e);
+            document.body.style.cursor = getCursor(edge);
         };
 
         const handleMouseDown = async (e: MouseEvent) => {
             const edge = detectEdge(e);
             if (edge) {
                 e.preventDefault();
-                resizeEdge = edge;
-                resizeStartPos = { x: e.screenX, y: e.screenY };
-
                 try {
-                    const size = await getCurrentWindow().innerSize();
-                    const pos = await getCurrentWindow().outerPosition();
-                    windowStartSize = { width: size.width, height: size.height };
-                    windowStartPos = { x: pos.x, y: pos.y };
+                    await currentWindow.startResizeDragging(getResizeDirection(edge));
                 } catch (e) {
-                    console.error("[PetWindow] Failed to get window info:", e);
+                    console.error("[PetWindow] Failed to start resize drag:", e);
                 }
             }
         };
 
         const handleMouseUp = () => {
-            if (resizeEdge && windowStartSize) {
-                // Save window size after resize
-                getCurrentWindow().innerSize().then(size => {
-                    invoke<PetConfig>("get_pet_config").then(cfg => {
-                        invoke("save_pet_config", {
-                            config: { ...cfg, window_width: size.width, window_height: size.height }
-                        }).catch(console.error);
-                    }).catch(console.error);
-                }).catch(console.error);
-            }
-            resizeEdge = null;
-            resizeStartPos = null;
-            windowStartSize = null;
-            windowStartPos = null;
             document.body.style.cursor = 'default';
+        };
+
+        const handleWheel = (e: WheelEvent) => {
+            if (!e.ctrlKey) return;
+            e.preventDefault();
+
+            const delta = e.deltaY > 0 ? -0.05 : 0.05;
+            const nextMultiplier = Math.max(0.5, Math.min(2.5, userScaleMultiplierRef.current + delta));
+            userScaleMultiplierRef.current = nextMultiplier;
+            setScaleMultiplier(nextMultiplier);
+
+            invoke<PetConfig>("get_pet_config").then(cfg => {
+                invoke("save_pet_config", {
+                    config: { ...cfg, model_scale: nextMultiplier }
+                }).catch(console.error);
+            }).catch(console.error);
         };
 
         document.addEventListener('mousemove', handleMouseMove);
@@ -297,13 +223,44 @@ export default function PetWindow() {
         document.addEventListener('wheel', handleWheel, { passive: false });
 
         return () => {
+            currentWindow.setResizable(false).catch(console.error);
             document.removeEventListener('mousemove', handleMouseMove);
             document.removeEventListener('mousedown', handleMouseDown);
             document.removeEventListener('mouseup', handleMouseUp);
             document.removeEventListener('wheel', handleWheel);
             document.body.style.cursor = 'default';
         };
-    }, [isResizeMode]);
+    }, [currentWindow, isResizeMode]);
+
+    useEffect(() => {
+        if (!isResizeMode) return;
+
+        let saveTimer: ReturnType<typeof setTimeout> | null = null;
+        let unlistenResize: (() => void) | undefined;
+
+        currentWindow.onResized(({ payload: size }) => {
+            setCanvasSize({ width: size.width, height: size.height });
+            setTimeout(() => {
+                viewerRef.current?.fitToView();
+            }, 0);
+
+            if (saveTimer) clearTimeout(saveTimer);
+            saveTimer = setTimeout(() => {
+                invoke<PetConfig>("get_pet_config").then(cfg => {
+                    invoke("save_pet_config", {
+                        config: { ...cfg, window_width: size.width, window_height: size.height }
+                    }).catch(console.error);
+                }).catch(console.error);
+            }, 150);
+        }).then(fn => {
+            unlistenResize = fn;
+        }).catch(console.error);
+
+        return () => {
+            if (saveTimer) clearTimeout(saveTimer);
+            unlistenResize?.();
+        };
+    }, [currentWindow, isResizeMode]);
 
     // Right-click: short click for menu, drag for window move
     useEffect(() => {
@@ -573,7 +530,7 @@ export default function PetWindow() {
                     }}>
                         <div>调整大小模式</div>
                         <div style={{ fontSize: "11px", marginTop: "4px", opacity: 0.8 }}>
-                            拖动边缘调整窗口 · Ctrl+滚轮缩放模型
+                            拖动边缘调整窗口大小 · Ctrl+滚轮微调模型
                         </div>
                     </div>
                 </>
@@ -589,6 +546,7 @@ export default function PetWindow() {
                     displayMode="full"
                     gazeTracking={true}
                     fixedSize={canvasSize || undefined}
+                    scaleMultiplier={scaleMultiplier}
                     onModelLoaded={handleModelLoaded}
                 />}
             </div>


### PR DESCRIPTION
## Summary / 概述

Fix pet window resizing on Niri, where the pet window resize path was not working correctly. This change switches the pet window to native resize dragging, updates the required Tauri permissions, and ensures the Live2D viewer re-fits correctly after window size changes and user scale adjustments.

修复 Niri 下宠物窗口缩放路径无法正常工作的问题。这个改动改为使用原生窗口缩放拖拽，补齐所需的 Tauri 权限，并确保 Live2D 视图在窗口尺寸变化和用户缩放调整后正确适配。

## Changes / 变更内容

- Added the Tauri pet window permissions needed for native resize dragging and resizable state updates
- Reworked pet window edge/corner resize handling to use `startResizeDragging` instead of manual resize math, restoring resize support on Niri
- Added resize event persistence so pet window size is saved after resize settles
- Added a persisted user scale multiplier for the pet model and wired Ctrl+wheel scaling through window config
- Exposed `fitToView()` from `Live2DViewer` and updated fit logic so fixed-size pet windows bottom-align and re-fit correctly after resize
- Updated pet window and Live2D viewer integration so model scale and canvas size stay in sync on Linux window managers such as Niri

## Type / 类型

- [ ] `feat` — New feature / 新功能
- [x] `fix` — Bug fix / Bug 修复
- [ ] `refactor` — Code refactoring / 代码重构
- [ ] `docs` — Documentation / 文档
- [ ] `style` — UI/CSS changes / 界面样式
- [ ] `test` — Tests / 测试
- [ ] `chore` — Build/tooling / 构建工具

## Testing / 测试

<!-- How was this tested? / 如何测试的？ -->

- [x] `npm run tauri dev` runs without errors
- [x] `npx tsc --noEmit` passes
- [x] `cargo check` passes
- [x] Manually tested the feature

Manual testing included:
- resizing the pet window from edges and corners on Linux
- verifying Live2D re-fit behavior after resize
- verifying Ctrl+wheel model scaling persistence
- verifying that the pet window can actually be resized under Niri

## Screenshots / 截图

<img width="1920" height="1080" alt="Screenshot from 2026-03-24 14-17-42" src="https://github.com/user-attachments/assets/a171712d-dbc1-4ba5-8837-35b727f56dac" />

## Related Issues / 相关 Issue

N/A
