### PR TITLE
fix: restore OpenAI TTS voice handling and streaming playback

### DIFF
--- a/src-tauri/src/tts/openai.rs
+++ b/src-tauri/src/tts/openai.rs
@@ -20,6 +20,7 @@ struct TtsRequest {
 
 pub struct OpenAITtsProvider {
     client: Client,
+    provider_id: String,
     api_key: String,
     base_url: String,
     model: String,
@@ -28,6 +29,7 @@ pub struct OpenAITtsProvider {
 
 impl OpenAITtsProvider {
     pub fn new(
+        provider_id: String,
         api_key: String,
         base_url: Option<String>,
         model: Option<String>,
@@ -38,6 +40,7 @@ impl OpenAITtsProvider {
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
                 .expect("HTTP client build should not fail"),
+            provider_id,
             api_key,
             base_url: base_url.unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
             model: model.unwrap_or_else(|| "tts-1".to_string()),
@@ -49,18 +52,26 @@ impl OpenAITtsProvider {
     pub fn from_config(config: &ProviderConfig) -> Option<Self> {
         let api_key = config.resolve_api_key()?;
         Some(Self::new(
+            config.id.clone(),
             api_key,
             config.base_url.clone(),
             config.model.clone(),
             config.default_voice.clone(),
         ))
     }
+
+    fn normalize_voice_id(&self, raw_voice: &str) -> String {
+        raw_voice
+            .strip_prefix(&format!("{}_", self.provider_id))
+            .unwrap_or(raw_voice)
+            .to_string()
+    }
 }
 
 #[async_trait]
 impl TtsProvider for OpenAITtsProvider {
     fn id(&self) -> String {
-        "openai".to_string()
+        self.provider_id.clone()
     }
 
     fn capabilities(&self) -> ProviderCapabilities {
@@ -88,12 +99,12 @@ impl TtsProvider for OpenAITtsProvider {
         voices
             .into_iter()
             .map(|(name, gender)| VoiceProfile {
-                voice_id: format!("openai_{}", name),
+                voice_id: format!("{}_{}", self.provider_id, name),
                 name: name.to_string(),
                 gender,
                 language: "en".to_string(),
                 engine: TtsEngine::Cloud,
-                provider_id: "openai".to_string(),
+                provider_id: self.provider_id.clone(),
                 extra_params: Default::default(),
             })
             .collect()
@@ -109,7 +120,7 @@ impl TtsProvider for OpenAITtsProvider {
         let request_body = TtsRequest {
             model: self.model.clone(),
             input: text.to_string(),
-            voice: raw_voice.strip_prefix("openai_").unwrap_or(&raw_voice).to_string(),
+            voice: self.normalize_voice_id(&raw_voice),
             response_format: "mp3".to_string(),
             speed: params.speed,
         };
@@ -165,7 +176,7 @@ impl TtsProvider for OpenAITtsProvider {
         let request_body = TtsRequest {
             model: self.model.clone(),
             input: text.to_string(),
-            voice: raw_voice.strip_prefix("openai_").unwrap_or(&raw_voice).to_string(),
+            voice: self.normalize_voice_id(&raw_voice),
             response_format: "mp3".to_string(),
             speed: params.speed,
         };

--- a/src/core/services/tts-service.ts
+++ b/src/core/services/tts-service.ts
@@ -118,6 +118,7 @@ export class TtsService {
         const unlistenEnd = await listen<TtsEndEvent>("tts:end", (_event) => {
             if (this.generation !== gen) return;
             console.log("[TTS] Stream ended:", _event.payload.text);
+            audioPlayer.finishStream();
             this.stopVoiceInterrupt();
         });
         if (this.generation !== gen) { unlistenEnd(); return; }

--- a/src/lib/audio-player.ts
+++ b/src/lib/audio-player.ts
@@ -8,10 +8,16 @@ export interface AudioAnalysis {
 }
 
 export class AudioStreamManager {
-    private currentSource: AudioBufferSourceNode | null = null;
     private audioContext: AudioContext;
     private analyser: AnalyserNode;
-    private queue: AudioBuffer[] = [];
+    private audioElement: HTMLAudioElement;
+    private mediaElementSource: MediaElementAudioSourceNode;
+    private appendQueue: Uint8Array[] = [];
+    private mediaSource: MediaSource | null = null;
+    private sourceBuffer: SourceBuffer | null = null;
+    private objectUrl: string | null = null;
+    private streamEnded = false;
+    private playbackStarted = false;
     private _isPlaying = false;
     private analysisListeners: ((data: AudioAnalysis) => void)[] = [];
     private playStateListeners: ((playing: boolean) => void)[] = [];
@@ -21,11 +27,39 @@ export class AudioStreamManager {
         this.audioContext = new AudioContext();
         this.analyser = this.audioContext.createAnalyser();
         this.analyser.fftSize = 256;
+
+        this.audioElement = new Audio();
+        this.audioElement.preload = "auto";
+        this.audioElement.autoplay = false;
+        this.audioElement.crossOrigin = "anonymous";
+
+        this.mediaElementSource = this.audioContext.createMediaElementSource(this.audioElement);
+        this.mediaElementSource.connect(this.analyser);
         this.analyser.connect(this.audioContext.destination);
+
+        this.audioElement.onplay = () => {
+            this._isPlaying = true;
+            this.broadcastPlayState(true);
+            if (!this.animationFrameId) {
+                this.startAnalysis();
+            }
+        };
+
+        this.audioElement.onpause = () => {
+            if (this.audioElement.ended) return;
+            this._isPlaying = false;
+            this.broadcastPlayState(false);
+        };
+
+        this.audioElement.onended = () => {
+            this._isPlaying = false;
+            this.broadcastAnalysis({ amplitude: 0, lowFreqEnergy: 0, highFreqEnergy: 0 });
+            this.broadcastPlayState(false);
+        };
     }
 
     public async resume() {
-        if (this.audioContext.state === 'suspended') {
+        if (this.audioContext.state === "suspended") {
             await this.audioContext.resume();
         }
     }
@@ -33,23 +67,19 @@ export class AudioStreamManager {
     public async queueAudio(data: Uint8Array | number[]) {
         await this.resume();
 
-        // Ensure we have an ArrayBuffer
-        let buffer: ArrayBuffer;
-        if (data instanceof Uint8Array) {
-            buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
-        } else {
-            buffer = new Uint8Array(data).buffer as ArrayBuffer;
+        const chunk = data instanceof Uint8Array ? data : new Uint8Array(data);
+        if (chunk.byteLength === 0) {
+            return;
         }
 
-        try {
-            const audioBuffer = await this.audioContext.decodeAudioData(buffer);
-            this.queue.push(audioBuffer);
-            if (!this._isPlaying) {
-                this.playNext();
-            }
-        } catch (e) {
-            console.error("Failed to decode audio:", e);
-        }
+        this.ensureStream();
+        this.appendQueue.push(chunk);
+        this.flushAppendQueue();
+    }
+
+    public finishStream() {
+        this.streamEnded = true;
+        this.tryEndStream();
     }
 
     public addAmplitudeListener(callback: (data: AudioAnalysis) => void) {
@@ -72,21 +102,31 @@ export class AudioStreamManager {
     }
 
     public stop() {
-        // Clear queue first
-        this.queue = [];
-
-        if (this.currentSource) {
-            try {
-                this.currentSource.stop();
-                this.currentSource.disconnect();
-            } catch (e) {
-                // Ignore errors if already stopped
-            }
-            this.currentSource = null;
+        this.audioElement.pause();
+        if (this.objectUrl) {
+            this.audioElement.removeAttribute("src");
+            this.audioElement.load();
+            URL.revokeObjectURL(this.objectUrl);
+            this.objectUrl = null;
         }
+
+        if (this.mediaSource) {
+            try {
+                if (this.mediaSource.readyState === "open") {
+                    this.mediaSource.endOfStream();
+                }
+            } catch {
+                // Ignore end-of-stream errors during teardown.
+            }
+        }
+
+        this.mediaSource = null;
+        this.sourceBuffer = null;
+        this.appendQueue = [];
+        this.streamEnded = false;
+        this.playbackStarted = false;
         this._isPlaying = false;
 
-        // Cancel the RAF loop to stop wasting CPU when nothing is playing
         if (this.animationFrameId !== undefined) {
             cancelAnimationFrame(this.animationFrameId);
             this.animationFrameId = undefined;
@@ -100,39 +140,85 @@ export class AudioStreamManager {
         this.stop();
     }
 
-    private playNext() {
-        if (this.queue.length === 0) {
-            this._isPlaying = false;
-            this.broadcastAnalysis({ amplitude: 0, lowFreqEnergy: 0, highFreqEnergy: 0 });
-            this.broadcastPlayState(false);
+    private ensureStream() {
+        if (this.mediaSource || !("MediaSource" in window)) {
             return;
         }
 
-        const buffer = this.queue.shift();
-        if (!buffer) return;
+        if (!MediaSource.isTypeSupported("audio/mpeg")) {
+            throw new Error("MediaSource audio/mpeg is not supported in this environment");
+        }
 
-        this._isPlaying = true;
-        const source = this.audioContext.createBufferSource();
-        source.buffer = buffer;
-        this.currentSource = source;
+        const mediaSource = new MediaSource();
+        this.mediaSource = mediaSource;
+        this.objectUrl = URL.createObjectURL(mediaSource);
+        this.audioElement.src = this.objectUrl;
 
-        // Notify listeners that playback started
-        this.broadcastPlayState(true);
+        mediaSource.addEventListener("sourceopen", () => {
+            if (!this.mediaSource || this.sourceBuffer) {
+                return;
+            }
 
-        // Connect source -> analyser
-        // Analyser is persistent and connected to destination
-        source.connect(this.analyser);
+            this.sourceBuffer = this.mediaSource.addSourceBuffer("audio/mpeg");
+            this.sourceBuffer.mode = "sequence";
+            this.sourceBuffer.addEventListener("updateend", () => {
+                this.flushAppendQueue();
+            });
+            this.flushAppendQueue();
+        }, { once: true });
+    }
 
-        source.onended = () => {
-            this.currentSource = null;
-            this.playNext();
-        };
+    private flushAppendQueue() {
+        if (!this.sourceBuffer || this.sourceBuffer.updating) {
+            return;
+        }
 
-        source.start();
+        if (!this.mediaSource || this.mediaSource.readyState !== "open") {
+            return;
+        }
 
-        // Ensure analysis is running
-        if (!this.animationFrameId) {
-            this.startAnalysis();
+        const chunk = this.appendQueue.shift();
+        if (!chunk) {
+            this.tryEndStream();
+            return;
+        }
+
+        try {
+            this.sourceBuffer.appendBuffer(chunk);
+            this.startPlaybackIfNeeded();
+        } catch (error) {
+            console.error("[Audio] Failed to append streaming chunk:", error);
+            this.stop();
+        }
+    }
+
+    private startPlaybackIfNeeded() {
+        if (this.playbackStarted) {
+            return;
+        }
+
+        this.playbackStarted = true;
+        this.audioElement.play().catch(error => {
+            console.warn("[Audio] Autoplay blocked or playback failed:", error);
+            this.playbackStarted = false;
+        });
+    }
+
+    private tryEndStream() {
+        if (!this.streamEnded || !this.mediaSource || !this.sourceBuffer) {
+            return;
+        }
+
+        if (this.appendQueue.length > 0 || this.sourceBuffer.updating) {
+            return;
+        }
+
+        try {
+            if (this.mediaSource.readyState === "open") {
+                this.mediaSource.endOfStream();
+            }
+        } catch (error) {
+            console.warn("[Audio] Failed to finalize media stream:", error);
         }
     }
 
@@ -141,21 +227,19 @@ export class AudioStreamManager {
         const freqDomain = new Uint8Array(this.analyser.frequencyBinCount);
         const sampleRate = this.audioContext.sampleRate;
         const binCount = this.analyser.frequencyBinCount;
-        const binHz = sampleRate / (binCount * 2); // Hz per FFT bin
+        const binHz = sampleRate / (binCount * 2);
 
-        // Precompute bin ranges for frequency bands
         const lowStart = Math.floor(200 / binHz);
         const lowEnd = Math.min(Math.ceil(800 / binHz), binCount - 1);
         const highStart = Math.floor(1500 / binHz);
         const highEnd = Math.min(Math.ceil(4000 / binHz), binCount - 1);
 
         const update = () => {
-            if (this.audioContext.state === 'suspended') {
+            if (this.audioContext.state === "suspended") {
                 this.animationFrameId = requestAnimationFrame(update);
                 return;
             }
 
-            // Time-domain: RMS amplitude
             this.analyser.getByteTimeDomainData(timeDomain);
             let sum = 0;
             for (let i = 0; i < timeDomain.length; i++) {
@@ -165,7 +249,6 @@ export class AudioStreamManager {
             const rms = Math.sqrt(sum / timeDomain.length);
             const amplitude = Math.min(rms * 4.0, 1.0);
 
-            // Frequency-domain: band energies
             this.analyser.getByteFrequencyData(freqDomain);
 
             let lowSum = 0;
@@ -186,9 +269,9 @@ export class AudioStreamManager {
             const highFreqEnergy = highCount > 0 ? Math.min((highSum / highCount) / 180, 1.0) : 0;
 
             this.broadcastAnalysis({ amplitude, lowFreqEnergy, highFreqEnergy });
-
             this.animationFrameId = requestAnimationFrame(update);
         };
+
         update();
     }
 

--- a/src/ui/widgets/SettingsPanel.tsx
+++ b/src/ui/widgets/SettingsPanel.tsx
@@ -107,6 +107,48 @@ const tabs: { id: TabId; label: string; icon: typeof Key }[] = [
     { id: "backup", label: "settings.tabs.backup", icon: HardDrive },
 ];
 
+function getDefaultTtsVoice(providerId: string, voices: VoiceProfile[]): string {
+    if (providerId === "browser") {
+        return "";
+    }
+
+    if (providerId === "openai") {
+        return "alloy";
+    }
+
+    const providerVoice = voices.find(v => v.provider_id === providerId);
+    return providerVoice?.voice_id || "";
+}
+
+function normalizeTtsVoice(
+    providerId: string,
+    voice: string,
+    voices: VoiceProfile[],
+    ttsConfig?: TtsSystemConfig | null,
+): string {
+    if (!voice) {
+        if (providerId === "openai") {
+            const provider = ttsConfig?.providers.find(p => p.id === providerId);
+            return provider?.default_voice || "alloy";
+        }
+        return getDefaultTtsVoice(providerId, voices);
+    }
+
+    if (providerId === "browser") {
+        return voice === "browser_default" ? voice : "";
+    }
+
+    if (providerId === "openai") {
+        return voice;
+    }
+
+    const matchesProvider = voices.some(
+        v => v.provider_id === providerId && v.voice_id === voice
+    );
+
+    return matchesProvider ? voice : getDefaultTtsVoice(providerId, voices);
+}
+
 export default function SettingsPanel({ isOpen, onClose, backgroundControls, displayMode, onDisplayModeChange, customModelPath, onCustomModelChange, gazeTracking: gazeTrackingProp, onGazeTrackingChange, sttConfig: sttConfigProp, voiceInterrupt: _voiceInterruptProp, imageGenConfig: imageGenConfigProp, telegramConfig: _telegramConfigProp, onVisionConfigChange }: SettingsPanelProps) {
     const { t, i18n } = useTranslation();
     const [activeTab, setActiveTab] = useState<TabId>("bg");
@@ -132,7 +174,7 @@ export default function SettingsPanel({ isOpen, onClose, backgroundControls, dis
             setLocalGazeTracking(gazeTrackingProp ?? true);
             setLocalBgConfig({ ...bg.config });
             setPersonaText(localStorage.getItem("kokoro_persona") || "You are a friendly, warm companion character. Respond with personality and emotion.");
-            setTtsVoice(localStorage.getItem("kokoro_tts_voice") || "alloy");
+            setTtsVoice(localStorage.getItem("kokoro_tts_voice") || "");
             setTtsSpeed(localStorage.getItem("kokoro_tts_speed") || "1.0");
             setTtsPitch(localStorage.getItem("kokoro_tts_pitch") || "1.0");
             setTtsProviderId(localStorage.getItem("kokoro_tts_provider") || "browser");
@@ -163,7 +205,7 @@ export default function SettingsPanel({ isOpen, onClose, backgroundControls, dis
     const [persona, setPersonaText] = useState(() => localStorage.getItem("kokoro_persona") || "You are a friendly, warm companion character. Respond with personality and emotion.");
 
     // TTS state
-    const [ttsVoice, setTtsVoice] = useState(() => localStorage.getItem("kokoro_tts_voice") || "alloy");
+    const [ttsVoice, setTtsVoice] = useState(() => localStorage.getItem("kokoro_tts_voice") || "");
     const [ttsSpeed, setTtsSpeed] = useState(() => localStorage.getItem("kokoro_tts_speed") || "1.0");
     const [ttsPitch, setTtsPitch] = useState(() => localStorage.getItem("kokoro_tts_pitch") || "1.0");
     const [ttsProviderId, setTtsProviderId] = useState(() => localStorage.getItem("kokoro_tts_provider") || "browser");
@@ -247,6 +289,11 @@ export default function SettingsPanel({ isOpen, onClose, backgroundControls, dis
             console.error("[SettingsPanel] Failed to fetch telegram config:", e);
         }
     };
+
+    useEffect(() => {
+        if (ttsVoices.length === 0) return;
+        setTtsVoice(prev => normalizeTtsVoice(ttsProviderId, prev, ttsVoices, localTtsConfig));
+    }, [ttsProviderId, ttsVoices, localTtsConfig]);
 
     const handleSave = async () => {
         // Persist to localStorage (non-LLM settings)

--- a/src/ui/widgets/settings/TtsTab.tsx
+++ b/src/ui/widgets/settings/TtsTab.tsx
@@ -48,6 +48,16 @@ export default function TtsTab({
     const [editingProviderId, setEditingProviderId] = useState<string | null>(null);
     const [scannedModels, setScannedModels] = useState<Record<string, GptSovitsModels>>({});
     const { t } = useTranslation();
+    const activeProvider = ttsConfig?.providers.find(p => p.id === ttsProviderId);
+    const isActiveGptSovits = activeProvider?.provider_type === "gpt_sovits";
+    const isActiveOpenAI = activeProvider?.provider_type === "openai";
+    const activeVoices = voices.filter(v => v.provider_id === ttsProviderId);
+    const activeVoiceOptions = activeVoices.length === 0
+        ? [{ value: "", label: t("settings.tts.active_settings.no_voices") }]
+        : activeVoices.map(v => ({
+            value: v.voice_id,
+            label: `${v.name} (${v.gender} · ${v.language})`,
+        }));
 
     // Scan for GPT-SoVITS models when install_path changes
     const scanModels = useCallback(async (providerId: string, installPath: string) => {
@@ -104,8 +114,17 @@ export default function TtsTab({
     const updateProviderConfig = (index: number, update: Partial<ProviderConfigData>) => {
         if (!ttsConfig) return;
         const newProviders = [...ttsConfig.providers];
-        newProviders[index] = { ...newProviders[index], ...update };
+        const previousProvider = newProviders[index];
+        newProviders[index] = { ...previousProvider, ...update };
         onTtsConfigChange({ ...ttsConfig, providers: newProviders });
+
+        if (
+            previousProvider.id === ttsProviderId &&
+            previousProvider.provider_type === "openai" &&
+            update.default_voice !== undefined
+        ) {
+            onTtsVoiceChange(update.default_voice || "");
+        }
     };
 
     const removeProvider = (index: number) => {
@@ -165,23 +184,24 @@ export default function TtsTab({
                 </div>
 
                 {/* Voice Selector — hidden for GPT-SoVITS (voice is determined by model + ref audio) */}
-                {!ttsConfig?.providers.find(p => p.id === ttsProviderId && p.provider_type === "gpt_sovits") && (
+                {!isActiveGptSovits && (
                     <div>
                         <label className={labelClasses}>{t("settings.tts.active_settings.voice")}</label>
-                        <Select
-                            value={ttsVoice}
-                            onChange={onTtsVoiceChange}
-                            options={(() => {
-                                const filtered = voices.filter(v => v.provider_id === ttsProviderId);
-                                if (filtered.length === 0) {
-                                    return [{ value: "", label: t("settings.tts.active_settings.no_voices") }];
-                                }
-                                return filtered.map(v => ({
-                                    value: v.voice_id,
-                                    label: `${v.name} (${v.gender} · ${v.language})`,
-                                }));
-                            })()}
-                        />
+                        {isActiveOpenAI ? (
+                            <input
+                                type="text"
+                                value={ttsVoice}
+                                onChange={e => onTtsVoiceChange(e.target.value)}
+                                placeholder="alloy"
+                                className={clsx(inputClasses, "font-mono text-xs")}
+                            />
+                        ) : (
+                            <Select
+                                value={ttsVoice}
+                                onChange={onTtsVoiceChange}
+                                options={activeVoiceOptions}
+                            />
+                        )}
                     </div>
                 )}
 
@@ -514,6 +534,19 @@ export default function TtsTab({
                                                     value={provider.model || ""}
                                                     onChange={e => updateProviderConfig(index, { model: e.target.value })}
                                                     placeholder="tts-1"
+                                                    className={clsx(inputClasses, "font-mono text-xs")}
+                                                />
+                                            </div>
+                                        )}
+
+                                        {provider.provider_type === "openai" && (
+                                            <div>
+                                                <label className={labelClasses}>{t("settings.tts.active_settings.voice")}</label>
+                                                <input
+                                                    type="text"
+                                                    value={provider.default_voice || ""}
+                                                    onChange={e => updateProviderConfig(index, { default_voice: e.target.value })}
+                                                    placeholder="alloy"
                                                     className={clsx(inputClasses, "font-mono text-xs")}
                                                 />
                                             </div>


### PR DESCRIPTION
## Summary / 概述

This PR fixes OpenAI TTS voice handling for custom providers and replaces the broken chunk-by-chunk audio decoding path with proper streaming MP3 playback.

## Changes / 变更内容

- Fix OpenAI TTS provider IDs so custom OpenAI providers expose unique voice IDs and strip the current provider prefix before calling the OpenAI `/audio/speech` API
- Update the TTS settings UI so OpenAI uses a single plain voice input, provider default voice updates the active voice immediately, and browser voice defaults no longer inherit OpenAI values
- Replace per-chunk `decodeAudioData()` playback with `MediaSource`-based streaming MP3 playback and finalize the stream on `tts:end`
- Add streaming playback cleanup for object URLs and stream state teardown to make repeated playback and interruption more stable

## Type / 类型

- [ ] `feat` — New feature / 新功能
- [x] `fix` — Bug fix / Bug 修复
- [ ] `refactor` — Code refactoring / 代码重构
- [ ] `docs` — Documentation / 文档
- [ ] `style` — UI/CSS changes / 界面样式
- [ ] `test` — Tests / 测试
- [ ] `chore` — Build/tooling / 构建工具

## Testing / 测试

- [x] `npm run tauri dev` runs without errors
- [x] `npx tsc --noEmit` passes
- [x] `cargo check` passes
- [x] Manually tested the feature

## Screenshots / 截图

N/A

## Related Issues / 相关 Issue

N/A
