### PR TITLE
fix: support custom base urls for openai transcription

### DIFF
--- a/src-tauri/src/stt/openai.rs
+++ b/src-tauri/src/stt/openai.rs
@@ -7,6 +7,7 @@ use super::interface::{
 };
 use async_trait::async_trait;
 use reqwest::multipart;
+use reqwest::Url;
 use serde::Deserialize;
 use std::time::Duration;
 
@@ -36,6 +37,29 @@ impl OpenAIWhisperProvider {
                 .build()
                 .expect("HTTP client build should not fail"),
         }
+    }
+}
+
+fn transcription_url(base_url: &str) -> String {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return "https://api.openai.com/v1/audio/transcriptions".to_string();
+    }
+
+    if let Ok(mut url) = Url::parse(trimmed) {
+        let normalized_path = if url.path().trim_end_matches('/').ends_with("/audio/transcriptions") {
+            url.path().trim_end_matches('/').to_string()
+        } else {
+            format!("{}/audio/transcriptions", url.path().trim_end_matches('/'))
+        };
+        url.set_path(&normalized_path);
+        return url.to_string().trim_end_matches('/').to_string();
+    }
+
+    if trimmed.ends_with("/audio/transcriptions") {
+        trimmed.to_string()
+    } else {
+        format!("{}/audio/transcriptions", trimmed)
     }
 }
 
@@ -117,10 +141,7 @@ impl SttEngine for OpenAIWhisperProvider {
         let language = language.map(|s| s.to_string());
         let mime_type = mime_type.to_string();
         let file_name = file_name.to_string();
-        let url = format!(
-            "{}/audio/transcriptions",
-            self.base_url.trim_end_matches('/')
-        );
+        let url = transcription_url(&self.base_url);
         let url_arc = std::sync::Arc::new(url);
 
         let response = crate::utils::http::request_with_retry(
@@ -211,5 +232,58 @@ impl SttEngine for OpenAIWhisperProvider {
             segments,
             processing_time: start_time.elapsed(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::transcription_url;
+
+    #[test]
+    fn appends_v1_for_root_base_url() {
+        assert_eq!(
+            transcription_url("https://example.com"),
+            "https://example.com/audio/transcriptions"
+        );
+    }
+
+    #[test]
+    fn appends_transcriptions_for_v1_base_url() {
+        assert_eq!(
+            transcription_url("https://example.com/v1"),
+            "https://example.com/v1/audio/transcriptions"
+        );
+    }
+
+    #[test]
+    fn preserves_existing_transcriptions_path() {
+        assert_eq!(
+            transcription_url("https://example.com/custom/audio/transcriptions"),
+            "https://example.com/custom/audio/transcriptions"
+        );
+    }
+
+    #[test]
+    fn trims_whitespace_and_trailing_slash() {
+        assert_eq!(
+            transcription_url(" https://example.com/v1/ "),
+            "https://example.com/v1/audio/transcriptions"
+        );
+    }
+
+    #[test]
+    fn preserves_query_parameters_on_full_endpoint() {
+        assert_eq!(
+            transcription_url("https://example.com/audio/transcriptions?api-version=2024-06-01"),
+            "https://example.com/audio/transcriptions?api-version=2024-06-01"
+        );
+    }
+
+    #[test]
+    fn preserves_custom_prefix_without_injecting_v1() {
+        assert_eq!(
+            transcription_url("https://example.com/openai"),
+            "https://example.com/openai/audio/transcriptions"
+        );
     }
 }

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -240,6 +240,7 @@
             },
             "fields": {
                 "server_url": "Server URL",
+                "base_url": "Base URL (Optional)",
                 "api_key_hint": "API Key (Leave empty to use env var)",
                 "model": "Model",
                 "model_path": "Model Path (ONNX)",

--- a/src/ui/locales/ja.json
+++ b/src/ui/locales/ja.json
@@ -240,6 +240,7 @@
             },
             "fields": {
                 "server_url": "サーバーURL",
+                "base_url": "ベースURL (オプション)",
                 "api_key_hint": "APIキー (環境変数を使用する場合は空のまま)",
                 "model": "モデル",
                 "model_path": "モデルパス (ONNX)",

--- a/src/ui/locales/ko.json
+++ b/src/ui/locales/ko.json
@@ -240,6 +240,7 @@
             },
             "fields": {
                 "server_url": "서버 URL",
+                "base_url": "기본 URL (선택사항)",
                 "api_key_hint": "API 키 (환경 변수 사용 시 비워둘 것)",
                 "model": "모델",
                 "model_path": "모델 경로 (ONNX)",

--- a/src/ui/locales/zh.json
+++ b/src/ui/locales/zh.json
@@ -240,6 +240,7 @@
             },
             "fields": {
                 "server_url": "服务器地址",
+                "base_url": "API 地址 (可选)",
                 "api_key_hint": "API Key (留空以使用环境变量)",
                 "model": "模型",
                 "model_path": "模型路径 (ONNX)",

--- a/src/ui/widgets/settings/SttTab.tsx
+++ b/src/ui/widgets/settings/SttTab.tsx
@@ -356,15 +356,21 @@ export default function SttTab({
                                     />
                                 ) : (
                                     <div className="grid grid-cols-1 gap-3">
-                                        {/* Base URL (for local providers) */}
-                                        {activeProvider.provider_type !== 'openai_whisper' && (
+                                        {/* Base URL */}
+                                        {(activeProvider.provider_type === 'openai_whisper' || activeProvider.provider_type === 'whisper_cpp' || activeProvider.provider_type === 'faster_whisper' || activeProvider.provider_type === 'sensevoice') && (
                                             <div className="space-y-1">
-                                                <div className="text-xs text-[var(--color-text-secondary)]">{t("settings.stt.fields.server_url")}</div>
+                                                <div className="text-xs text-[var(--color-text-secondary)]">
+                                                    {activeProvider.provider_type === 'openai_whisper'
+                                                        ? t("settings.stt.fields.base_url")
+                                                        : t("settings.stt.fields.server_url")}
+                                                </div>
                                                 <input
                                                     type="text"
                                                     value={activeProvider.base_url || ""}
                                                     onChange={(e) => updateProvider(activeProvider.id, { base_url: e.target.value })}
-                                                    placeholder="http://127.0.0.1:8080"
+                                                    placeholder={activeProvider.provider_type === 'openai_whisper'
+                                                        ? "https://api.openai.com/v1"
+                                                        : "http://127.0.0.1:8080"}
                                                     className="w-full px-3 py-1.5 rounded-md text-sm bg-[var(--color-bg-elevated)] border border-[var(--color-border)] focus:border-[var(--color-accent)] outline-none"
                                                 />
                                             </div>


### PR DESCRIPTION
## Summary / 概述

Fix OpenAI transcription custom base URL support in STT settings and request handling.

## Changes / 变更内容

- Add a `Base URL` field for the `openai_whisper` STT provider in settings UI.
- Add Rust tests covering custom prefixes, full transcription endpoints, and query parameter preservation.

## Type / 类型

- [ ] `feat` — New feature / 新功能
- [x] `fix` — Bug fix / Bug 修复
- [ ] `refactor` — Code refactoring / 代码重构
- [ ] `docs` — Documentation / 文档
- [ ] `style` — UI/CSS changes / 界面样式
- [ ] `test` — Tests / 测试
- [ ] `chore` — Build/tooling / 构建工具

## Testing / 测试

- [x] `npm run tauri dev` runs without errors
- [x] `npx tsc --noEmit` passes
- [x] `cargo check` passes
- [x] Manually tested the feature

## Screenshots / 截图

N/A

## Related Issues / 相关 Issue

N/A
