### PR TITLE
fix: reduce Live2D CPU usage and unify render FPS settings

### DIFF
--- a/src-tauri/src/commands/pet.rs
+++ b/src-tauri/src/commands/pet.rs
@@ -14,6 +14,12 @@ pub struct PetConfig {
     pub window_height: u32,
     #[serde(default)]
     pub model_scale: f32,
+    #[serde(default = "default_render_fps")]
+    pub render_fps: u32,
+}
+
+fn default_render_fps() -> u32 {
+    60
 }
 
 impl Default for PetConfig {
@@ -27,6 +33,7 @@ impl Default for PetConfig {
             window_width: 0,
             window_height: 0,
             model_scale: 0.0,
+            render_fps: default_render_fps(),
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useSyncExternalStore } from "react";
 import { motion } from "framer-motion";
 import { Settings } from "lucide-react";
+import { emit } from "@tauri-apps/api/event";
 import { LayoutRenderer } from "./ui/layout/LayoutRenderer";
 import { LayoutConfig } from "./ui/layout/types";
 import { ThemeProvider } from "./ui/theme/ThemeContext";
@@ -18,7 +19,7 @@ import { live2dUrl } from "./lib/utils";
 registerCoreComponents();
 
 // Build layout config as a function of displayMode
-function createLayout(displayMode: { mode: Live2DDisplayMode; modelUrl: string; gazeTracking: boolean }): LayoutConfig {
+function createLayout(displayMode: { mode: Live2DDisplayMode; modelUrl: string; gazeTracking: boolean; renderFps: number }): LayoutConfig {
   return {
     root: {
       id: "root-layer",
@@ -33,6 +34,7 @@ function createLayout(displayMode: { mode: Live2DDisplayMode; modelUrl: string; 
             modelUrl: displayMode.modelUrl,
             displayMode: displayMode.mode,
             gazeTracking: displayMode.gazeTracking,
+            maxFps: displayMode.renderFps,
           }
         },
         {
@@ -73,7 +75,7 @@ function createLayout(displayMode: { mode: Live2DDisplayMode; modelUrl: string; 
   };
 }
 
-import { convertFileSrc } from "@tauri-apps/api/core";
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import {
   onImageGenDone,
   onModThemeOverride,
@@ -167,6 +169,10 @@ const _subscribeFn = (cb: () => void) => {
 };
 const _getSnap = () => _regSnap;
 
+interface PetConfig {
+  render_fps?: number;
+}
+
 function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [displayMode, setDisplayMode] = useState<Live2DDisplayMode>(
@@ -185,6 +191,7 @@ function App() {
   const [gazeTracking, setGazeTracking] = useState<boolean>(
     () => localStorage.getItem("kokoro_gaze_tracking") !== "false"
   );
+  const [renderFps, setRenderFps] = useState<number>(60);
 
   const handleGazeTrackingChange = (enabled: boolean) => {
     setGazeTracking(enabled);
@@ -238,7 +245,10 @@ function App() {
     return "/live2d/haru/haru_greeter_t03.model3.json";
   }, [customModelPath]);
 
-  const layout = useMemo(() => createLayout({ mode: displayMode, modelUrl, gazeTracking }), [displayMode, modelUrl, gazeTracking]);
+  const layout = useMemo(
+    () => createLayout({ mode: displayMode, modelUrl, gazeTracking, renderFps }),
+    [displayMode, modelUrl, gazeTracking, renderFps]
+  );
 
   const handleDisplayModeChange = (mode: Live2DDisplayMode) => {
     setDisplayMode(mode);
@@ -251,6 +261,19 @@ function App() {
       localStorage.setItem("kokoro_custom_model_path", path);
     } else {
       localStorage.removeItem("kokoro_custom_model_path");
+    }
+  };
+
+  const handleRenderFpsChange = async (fps: number) => {
+    setRenderFps(fps);
+
+    try {
+      const cfg = await invoke<PetConfig>("get_pet_config");
+      const nextConfig = { ...cfg, render_fps: fps };
+      await invoke("save_pet_config", { config: nextConfig });
+      await emit("pet-config-updated", nextConfig);
+    } catch (e) {
+      console.error("[App] Failed to persist render FPS:", e);
     }
   };
 
@@ -279,6 +302,10 @@ function App() {
 
   useEffect(() => {
     ttsService.init();
+
+    invoke<PetConfig>("get_pet_config")
+      .then((cfg) => setRenderFps(typeof cfg.render_fps === "number" ? cfg.render_fps : 60))
+      .catch(err => console.error("[App] Failed to load pet config:", err));
 
     // Fetch initial data for settings
     // Fetch initial data — split into fast (configs) and slow (scans) batches
@@ -911,6 +938,8 @@ function App() {
             onCustomModelChange={handleCustomModelChange}
             gazeTracking={gazeTracking}
             onGazeTrackingChange={handleGazeTrackingChange}
+            renderFps={renderFps}
+            onRenderFpsChange={handleRenderFpsChange}
             // External state for Mod
             availableModels={availableModels}
             persona={persona}

--- a/src/core/services/voice-interrupt-service.ts
+++ b/src/core/services/voice-interrupt-service.ts
@@ -24,6 +24,7 @@ export class VoiceInterruptService {
     private aboveThresholdSince: number | null = null;
     private lastInterruptTime = 0;
     private listeners: InterruptCallback[] = [];
+    private analysisBuffer: Uint8Array | null = null;
 
     /**
      * Start listening for voice activity on the microphone.
@@ -53,6 +54,7 @@ export class VoiceInterruptService {
         this.sourceNode = this.audioCtx.createMediaStreamSource(this.stream);
         this.sourceNode.connect(this.analyser);
         // Do NOT connect analyser to destination — we don't want to play mic audio
+        this.analysisBuffer = new Uint8Array(this.analyser.frequencyBinCount);
 
         this.active = true;
         this.aboveThresholdSince = null;
@@ -89,6 +91,7 @@ export class VoiceInterruptService {
         }
 
         this.analyser = null;
+        this.analysisBuffer = null;
         this.aboveThresholdSince = null;
 
         console.log("[VoiceInterrupt] Stopped");
@@ -120,7 +123,8 @@ export class VoiceInterruptService {
     private detectLoop = (): void => {
         if (!this.active || !this.analyser) return;
 
-        const dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+        const dataArray = this.analysisBuffer;
+        if (!dataArray) return;
         this.analyser.getByteTimeDomainData(dataArray);
 
         // Calculate RMS

--- a/src/features/live2d/Live2DViewer.tsx
+++ b/src/features/live2d/Live2DViewer.tsx
@@ -38,7 +38,8 @@ export type Live2DDisplayMode = "full" | "upper" | "upper-thigh";
 export interface Live2DViewerProps {
     /** URL to the .model3.json file */
     modelUrl: string;
-    /** Optional controller instance to manage the model state */
+    /** Optional controller instance to manage the model state.
+     * Chat expression/action events are routed through this controller when provided. */
     controller?: Live2DController;
     /** Called when a hit area on the model is tapped (legacy) */
     onHitAreaTap?: (hitArea: string) => void;
@@ -117,7 +118,8 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
             };
         });
 
-        // Listen for LLM expression events and apply to Live2D model
+        // Centralize chat-driven animation listeners here so both the main stage
+        // and the floating pet window react through the same controller instance.
         useEffect(() => {
             let unlisten: (() => void) | undefined;
 
@@ -131,7 +133,8 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
             return () => { unlisten?.(); };
         }, [getActiveController]);
 
-        // Listen for LLM action/motion events and apply to Live2D model
+        // Keep action/motion routing colocated with expression routing to avoid
+        // duplicate listeners in individual windows such as PetWindow.
         useEffect(() => {
             let unlisten: (() => void) | undefined;
 
@@ -168,6 +171,13 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
             scaleMultiplierRef.current = scaleMultiplier;
             fitModelRef.current?.();
         }, [scaleMultiplier]);
+
+        useEffect(() => {
+            const app = appRef.current;
+            if (!app) return;
+
+            app.ticker.maxFPS = maxFps > 0 ? maxFps : 0;
+        }, [maxFps]);
 
         // Gaze tracking: model eyes follow cursor
         const handlePointerMove = useCallback((e: PIXI.InteractionEvent) => {
@@ -436,7 +446,7 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
                 }
                 appRef.current = null;
             };
-        }, [modelUrl, backgroundAlpha, displayMode, handlePointerMove, onHitAreaTap, getActiveController, maxFps]);
+        }, [modelUrl, backgroundAlpha, displayMode, handlePointerMove, onHitAreaTap, getActiveController]);
 
         useEffect(() => {
             if (!fixedSize) return;

--- a/src/features/live2d/Live2DViewer.tsx
+++ b/src/features/live2d/Live2DViewer.tsx
@@ -54,6 +54,8 @@ export interface Live2DViewerProps {
     fixedSize?: { width: number; height: number };
     /** Optional user scale multiplier applied on top of auto-fit */
     scaleMultiplier?: number;
+    /** Max render FPS. Use 0 for unlimited. */
+    maxFps?: number;
     /** Callback when model is loaded and sized */
     onModelLoaded?: (bounds: { width: number; height: number }) => void;
 }
@@ -61,7 +63,7 @@ export interface Live2DViewerProps {
 // ── Component ──────────────────────────────────────
 
 const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
-    ({ modelUrl, controller, onHitAreaTap, className, backgroundAlpha = 0, displayMode = "full", gazeTracking = true, fixedSize, scaleMultiplier = 1, onModelLoaded }, ref) => {
+    ({ modelUrl, controller, onHitAreaTap, className, backgroundAlpha = 0, displayMode = "full", gazeTracking = true, fixedSize, scaleMultiplier = 1, maxFps = 60, onModelLoaded }, ref) => {
         const containerRef = useRef<HTMLDivElement>(null);
         const appRef = useRef<PIXI.Application | null>(null);
         const modelRef = useRef<Live2DModel | null>(null);
@@ -186,7 +188,9 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
                 height: fixedSize?.height,
                 antialias: true,
                 autoStart: true,
+                powerPreference: fixedSize ? "low-power" : "high-performance",
             });
+            app.ticker.maxFPS = maxFps > 0 ? maxFps : 0;
             appRef.current = app;
             container.appendChild(app.view as HTMLCanvasElement);
 
@@ -197,6 +201,8 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
 
             // Load the Live2D model
             let cancelled = false;
+            let tick: ((delta: number) => void) | null = null;
+            let syncTickerState: (() => void) | null = null;
 
             // Clear PIXI texture cache to avoid stale error results from previous loads
             PIXI.utils.clearTextureCache();
@@ -380,16 +386,24 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
                     app.stage.addChild(model as unknown as PIXI.DisplayObject);
 
                     // Add update loop
-                    app.ticker.add((delta: number) => {
+                    tick = (delta: number) => {
                         const ctrl = getActiveController();
                         if (ctrl) {
-                            // Delta in Pixi is frame-dependent (1 = 60fps). 
-                            // Controller might expect seconds or ms?
-                            // let's assume controller.update expects delta 
-                            // We'll pass the raw delta for now (frames)
                             ctrl.update(delta);
                         }
-                    });
+                    };
+                    app.ticker.add(tick);
+
+                    syncTickerState = () => {
+                        if (document.hidden) {
+                            app.stop();
+                        } else {
+                            app.start();
+                        }
+                    };
+
+                    document.addEventListener("visibilitychange", syncTickerState);
+                    syncTickerState();
 
                 } catch (err) {
                     console.error("[Live2DViewer] Failed to load model:", err);
@@ -409,6 +423,12 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
                 fitModelRef.current = null;
 
                 app.stage.off("pointermove", handlePointerMove);
+                if (syncTickerState) {
+                    document.removeEventListener("visibilitychange", syncTickerState);
+                }
+                if (tick) {
+                    app.ticker.remove(tick);
+                }
                 try {
                     app.destroy(true, { children: true, texture: true });
                 } catch (e) {
@@ -416,7 +436,7 @@ const Live2DViewer = forwardRef<Live2DViewerHandle, Live2DViewerProps>(
                 }
                 appRef.current = null;
             };
-        }, [modelUrl, backgroundAlpha, displayMode, handlePointerMove, onHitAreaTap, getActiveController]);
+        }, [modelUrl, backgroundAlpha, displayMode, handlePointerMove, onHitAreaTap, getActiveController, maxFps]);
 
         useEffect(() => {
             if (!fixedSize) return;

--- a/src/lib/audio-player.ts
+++ b/src/lib/audio-player.ts
@@ -22,6 +22,7 @@ export class AudioStreamManager {
     private analysisListeners: ((data: AudioAnalysis) => void)[] = [];
     private playStateListeners: ((playing: boolean) => void)[] = [];
     private animationFrameId?: number;
+    private analysisActive = false;
 
     constructor() {
         this.audioContext = new AudioContext();
@@ -40,19 +41,19 @@ export class AudioStreamManager {
         this.audioElement.onplay = () => {
             this._isPlaying = true;
             this.broadcastPlayState(true);
-            if (!this.animationFrameId) {
-                this.startAnalysis();
-            }
+            this.startAnalysis();
         };
 
         this.audioElement.onpause = () => {
             if (this.audioElement.ended) return;
             this._isPlaying = false;
+            this.stopAnalysis();
             this.broadcastPlayState(false);
         };
 
         this.audioElement.onended = () => {
             this._isPlaying = false;
+            this.stopAnalysis();
             this.broadcastAnalysis({ amplitude: 0, lowFreqEnergy: 0, highFreqEnergy: 0 });
             this.broadcastPlayState(false);
         };
@@ -127,10 +128,7 @@ export class AudioStreamManager {
         this.playbackStarted = false;
         this._isPlaying = false;
 
-        if (this.animationFrameId !== undefined) {
-            cancelAnimationFrame(this.animationFrameId);
-            this.animationFrameId = undefined;
-        }
+        this.stopAnalysis();
 
         this.broadcastAnalysis({ amplitude: 0, lowFreqEnergy: 0, highFreqEnergy: 0 });
         this.broadcastPlayState(false);
@@ -223,6 +221,11 @@ export class AudioStreamManager {
     }
 
     private startAnalysis() {
+        if (this.analysisActive) {
+            return;
+        }
+
+        this.analysisActive = true;
         const timeDomain = new Uint8Array(this.analyser.frequencyBinCount);
         const freqDomain = new Uint8Array(this.analyser.frequencyBinCount);
         const sampleRate = this.audioContext.sampleRate;
@@ -235,6 +238,11 @@ export class AudioStreamManager {
         const highEnd = Math.min(Math.ceil(4000 / binHz), binCount - 1);
 
         const update = () => {
+            if (!this.analysisActive) {
+                this.animationFrameId = undefined;
+                return;
+            }
+
             if (this.audioContext.state === "suspended") {
                 this.animationFrameId = requestAnimationFrame(update);
                 return;
@@ -273,6 +281,15 @@ export class AudioStreamManager {
         };
 
         update();
+    }
+
+    private stopAnalysis() {
+        this.analysisActive = false;
+
+        if (this.animationFrameId !== undefined) {
+            cancelAnimationFrame(this.animationFrameId);
+            this.animationFrameId = undefined;
+        }
     }
 
     private broadcastAnalysis(data: AudioAnalysis) {

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -313,6 +313,15 @@
             "gaze_tracking": {
                 "label": "Gaze Tracking",
                 "desc": "Model eyes follow the mouse cursor"
+            },
+            "render_fps": {
+                "label": "Render FPS",
+                "options": {
+                    "fps_30": "30 FPS",
+                    "fps_60": "60 FPS",
+                    "unlimited": "Unlimited",
+                    "custom": "Custom"
+                }
             }
         },
         "image_gen": {

--- a/src/ui/locales/ja.json
+++ b/src/ui/locales/ja.json
@@ -313,6 +313,15 @@
             "gaze_tracking": {
                 "label": "視線追従",
                 "desc": "モデルの目がマウスカーソルを追従します"
+            },
+            "render_fps": {
+                "label": "描画 FPS",
+                "options": {
+                    "fps_30": "30 FPS",
+                    "fps_60": "60 FPS",
+                    "unlimited": "無制限",
+                    "custom": "カスタム"
+                }
             }
         },
         "image_gen": {

--- a/src/ui/locales/ko.json
+++ b/src/ui/locales/ko.json
@@ -313,6 +313,15 @@
             "gaze_tracking": {
                 "label": "시선 추적",
                 "desc": "모델의 눈이 마우스 커서를 따라갑니다"
+            },
+            "render_fps": {
+                "label": "렌더링 FPS",
+                "options": {
+                    "fps_30": "30 FPS",
+                    "fps_60": "60 FPS",
+                    "unlimited": "무제한",
+                    "custom": "사용자 지정"
+                }
             }
         },
         "image_gen": {

--- a/src/ui/locales/zh.json
+++ b/src/ui/locales/zh.json
@@ -313,6 +313,15 @@
             "gaze_tracking": {
                 "label": "视线跟随",
                 "desc": "模型眼球跟随鼠标光标移动"
+            },
+            "render_fps": {
+                "label": "渲染帧率",
+                "options": {
+                    "fps_30": "30 FPS",
+                    "fps_60": "60 FPS",
+                    "unlimited": "无限制",
+                    "custom": "自定义"
+                }
             }
         },
         "image_gen": {

--- a/src/ui/widgets/SettingsPanel.tsx
+++ b/src/ui/widgets/SettingsPanel.tsx
@@ -47,6 +47,8 @@ interface SettingsPanelProps {
     onCustomModelChange: (path: string | null) => void;
     gazeTracking?: boolean;
     onGazeTrackingChange?: (enabled: boolean) => void;
+    renderFps: number;
+    onRenderFpsChange: (fps: number) => void;
     // Optional props for external state management (Mod support)
     availableModels?: any[]; // Live2dModelInfo[]
     persona?: string;
@@ -149,7 +151,7 @@ function normalizeTtsVoice(
     return matchesProvider ? voice : getDefaultTtsVoice(providerId, voices);
 }
 
-export default function SettingsPanel({ isOpen, onClose, backgroundControls, displayMode, onDisplayModeChange, customModelPath, onCustomModelChange, gazeTracking: gazeTrackingProp, onGazeTrackingChange, sttConfig: sttConfigProp, voiceInterrupt: _voiceInterruptProp, imageGenConfig: imageGenConfigProp, telegramConfig: _telegramConfigProp, onVisionConfigChange }: SettingsPanelProps) {
+export default function SettingsPanel({ isOpen, onClose, backgroundControls, displayMode, onDisplayModeChange, customModelPath, onCustomModelChange, gazeTracking: gazeTrackingProp, onGazeTrackingChange, renderFps, onRenderFpsChange, sttConfig: sttConfigProp, voiceInterrupt: _voiceInterruptProp, imageGenConfig: imageGenConfigProp, telegramConfig: _telegramConfigProp, onVisionConfigChange }: SettingsPanelProps) {
     const { t, i18n } = useTranslation();
     const [activeTab, setActiveTab] = useState<TabId>("bg");
     const bg = backgroundControls;
@@ -527,6 +529,8 @@ export default function SettingsPanel({ isOpen, onClose, backgroundControls, dis
                                     onCustomModelPathChange={setLocalCustomModelPath}
                                     gazeTracking={localGazeTracking}
                                     onGazeTrackingChange={setLocalGazeTracking}
+                                    renderFps={renderFps}
+                                    onRenderFpsChange={onRenderFpsChange}
                                 />
                             )}
 

--- a/src/ui/widgets/settings/ModelTab.tsx
+++ b/src/ui/widgets/settings/ModelTab.tsx
@@ -16,12 +16,15 @@ export interface ModelTabProps {
     onCustomModelPathChange: (path: string | null) => void;
     gazeTracking?: boolean;
     onGazeTrackingChange?: (enabled: boolean) => void;
+    renderFps: number;
+    onRenderFpsChange: (fps: number) => void;
 }
 
 export default function ModelTab({
     displayMode, onDisplayModeChange,
     customModelPath, onCustomModelPathChange,
     gazeTracking = true, onGazeTrackingChange,
+    renderFps, onRenderFpsChange,
 }: ModelTabProps) {
     const { t } = useTranslation();
     const [isImporting, setIsImporting] = useState(false);
@@ -114,6 +117,24 @@ export default function ModelTab({
         { mode: "upper" as Live2DDisplayMode, label: t("settings.model.display_mode.upper"), desc: t("settings.model.display_mode.upper_desc") },
     ];
 
+    const renderFpsPreset = renderFps === 30 || renderFps === 60 || renderFps === 0
+        ? String(renderFps)
+        : "custom";
+
+    const handleRenderFpsPresetChange = (value: string) => {
+        if (value === "custom") {
+            onRenderFpsChange(renderFps > 0 && renderFps !== 30 && renderFps !== 60 ? renderFps : 45);
+            return;
+        }
+
+        onRenderFpsChange(Number(value));
+    };
+
+    const handleCustomRenderFpsChange = (value: string) => {
+        const parsed = Number.parseInt(value, 10);
+        onRenderFpsChange(Number.isFinite(parsed) && parsed > 0 ? parsed : 1);
+    };
+
     return (
         <div className="space-y-5">
             <div>
@@ -175,6 +196,32 @@ export default function ModelTab({
                         gazeTracking && "translate-x-5"
                     )} />
                 </button>
+            </div>
+
+            <div>
+                <label className={labelClasses}>{t("settings.model.render_fps.label")}</label>
+                <div className="mt-3 flex items-center gap-3">
+                    <select
+                        value={renderFpsPreset}
+                        onChange={(e) => handleRenderFpsPresetChange(e.target.value)}
+                        className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-surface-soft)] px-3 py-2 text-sm text-[var(--color-text-primary)] outline-none"
+                    >
+                        <option value="30">{t("settings.model.render_fps.options.fps_30")}</option>
+                        <option value="60">{t("settings.model.render_fps.options.fps_60")}</option>
+                        <option value="0">{t("settings.model.render_fps.options.unlimited")}</option>
+                        <option value="custom">{t("settings.model.render_fps.options.custom")}</option>
+                    </select>
+                    {renderFpsPreset === "custom" && (
+                        <input
+                            type="number"
+                            min={1}
+                            step={1}
+                            value={renderFps}
+                            onChange={(e) => handleCustomRenderFpsChange(e.target.value)}
+                            className="w-28 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-surface-soft)] px-3 py-2 text-sm text-[var(--color-text-primary)] outline-none"
+                        />
+                    )}
+                </div>
             </div>
 
             {/* Model List Section */}

--- a/src/ui/widgets/settings/PetTab.tsx
+++ b/src/ui/widgets/settings/PetTab.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { useTranslation } from "react-i18next";
 
 interface PetConfig {
@@ -112,10 +112,20 @@ export default function PetTab() {
         };
     }, []);
 
+    const persistConfig = useCallback(async (nextConfig: PetConfig, showSavedState = false) => {
+        setConfig(nextConfig);
+        await invoke("save_pet_config", { config: nextConfig }).catch(console.error);
+        await emit("pet-config-updated", nextConfig).catch(console.error);
+
+        if (showSavedState) {
+            setSaved(true);
+            setTimeout(() => setSaved(false), 2000);
+        }
+    }, []);
+
     const handleToggle = async (enabled: boolean) => {
         const newCfg = { ...config, enabled };
-        setConfig(newCfg);
-        await invoke("save_pet_config", { config: newCfg }).catch(console.error);
+        await persistConfig(newCfg);
         if (enabled) {
             console.log("[PetTab] Calling show_pet_window...");
             try {
@@ -131,16 +141,13 @@ export default function PetTab() {
     };
 
     const handleSave = async () => {
-        await invoke("save_pet_config", { config }).catch(console.error);
-        setSaved(true);
-        setTimeout(() => setSaved(false), 2000);
+        await persistConfig(config, true);
     };
 
     const handleResetPosition = async () => {
         await invoke("move_pet_window", { x: 100, y: 100 }).catch(console.error);
         const newCfg = { ...config, position_x: 100, position_y: 100 };
-        setConfig(newCfg);
-        await invoke("save_pet_config", { config: newCfg }).catch(console.error);
+        await persistConfig(newCfg);
     };
 
     const labelStyle: React.CSSProperties = {

--- a/src/windows/PetWindow.tsx
+++ b/src/windows/PetWindow.tsx
@@ -129,22 +129,6 @@ export default function PetWindow() {
         }
     }, []);
 
-    // Debug: log component mount + test right-click detection
-    useEffect(() => {
-        console.log("[PetWindow] Component mounted");
-
-        // Test: simple click detection
-        const testClick = (e: MouseEvent) => {
-            console.log("[PetWindow] Click detected:", e.button, "at", e.clientX, e.clientY);
-        };
-        document.addEventListener("click", testClick);
-
-        return () => {
-            console.log("[PetWindow] Component unmounted");
-            document.removeEventListener("click", testClick);
-        };
-    }, []);
-
     // Keep ref in sync for use in native event listeners
     useEffect(() => {
         isDragModeRef.current = isDragMode;
@@ -285,6 +269,40 @@ export default function PetWindow() {
         let dragStartPos: { x: number; y: number } | null = null;
         let windowStartPos: { x: number; y: number } | null = null;
         let hasMoved = false;
+        let pendingWindowPos: { x: number; y: number } | null = null;
+        let moveRafId: number | null = null;
+        let moveInFlight = false;
+
+        const flushWindowMove = async () => {
+            moveRafId = null;
+            if (!pendingWindowPos || moveInFlight) return;
+
+            const nextPos = pendingWindowPos;
+            pendingWindowPos = null;
+            moveInFlight = true;
+
+            try {
+                await currentWindow.setPosition(new PhysicalPosition(nextPos.x, nextPos.y));
+            } catch (e) {
+                console.error("[PetWindow] Failed to set position:", e);
+            } finally {
+                moveInFlight = false;
+                if (pendingWindowPos && isDragModeRef.current && moveRafId === null) {
+                    moveRafId = requestAnimationFrame(() => {
+                        void flushWindowMove();
+                    });
+                }
+            }
+        };
+
+        const scheduleWindowMove = (x: number, y: number) => {
+            pendingWindowPos = { x, y };
+            if (moveRafId !== null || moveInFlight) return;
+
+            moveRafId = requestAnimationFrame(() => {
+                void flushWindowMove();
+            });
+        };
 
         const handleMouseDown = async (e: MouseEvent) => {
             if (e.button === 2) { // Right button
@@ -294,13 +312,10 @@ export default function PetWindow() {
                 hasMoved = false;
                 rightClickStartRef.current = { x: e.clientX, y: e.clientY };
 
-                console.log("[PetWindow] Right mousedown at", e.clientX, e.clientY);
-
                 // Get current window position
                 try {
-                    const pos = await getCurrentWindow().outerPosition();
+                    const pos = await currentWindow.outerPosition();
                     windowStartPos = { x: pos.x, y: pos.y };
-                    console.log("[PetWindow] Window start position:", windowStartPos);
                 } catch (e) {
                     console.error("[PetWindow] Failed to get window position:", e);
                 }
@@ -311,7 +326,7 @@ export default function PetWindow() {
             }
         };
 
-        const handleMouseMove = async (e: MouseEvent) => {
+        const handleMouseMove = (e: MouseEvent) => {
             if (dragStartPos && windowStartPos && isDragModeRef.current) {
                 const dx = e.screenX - dragStartPos.x;
                 const dy = e.screenY - dragStartPos.y;
@@ -323,12 +338,7 @@ export default function PetWindow() {
                     // Move window
                     const newX = windowStartPos.x + dx;
                     const newY = windowStartPos.y + dy;
-
-                    try {
-                        await getCurrentWindow().setPosition(new PhysicalPosition(newX, newY));
-                    } catch (e) {
-                        console.error("[PetWindow] Failed to set position:", e);
-                    }
+                    scheduleWindowMove(newX, newY);
                 }
             }
         };
@@ -338,17 +348,13 @@ export default function PetWindow() {
                 e.preventDefault();
                 e.stopPropagation();
 
-                console.log("[PetWindow] Right mouseup, hasMoved:", hasMoved);
-
                 if (!hasMoved && rightClickStartRef.current) {
                     // No movement — show menu
                     const pos = rightClickStartRef.current;
-                    console.log("[PetWindow] Showing menu at", pos.x, pos.y);
                     setContextMenu({ visible: true, x: pos.x, y: pos.y });
                 } else if (hasMoved && windowStartPos) {
                     // Drag completed — save position
-                    console.log("[PetWindow] Drag completed, saving position");
-                    getCurrentWindow().outerPosition().then(pos => {
+                    currentWindow.outerPosition().then(pos => {
                         invoke<PetConfig>("get_pet_config").then(cfg => {
                             invoke("save_pet_config", {
                                 config: { ...cfg, position_x: pos.x, position_y: pos.y }
@@ -362,6 +368,7 @@ export default function PetWindow() {
                 isDragModeRef.current = false;
                 dragStartPos = null;
                 windowStartPos = null;
+                pendingWindowPos = null;
                 rightClickStartRef.current = null;
             }
         };
@@ -378,12 +385,15 @@ export default function PetWindow() {
         document.addEventListener("contextmenu", handleContextMenu, true);
 
         return () => {
+            if (moveRafId !== null) {
+                cancelAnimationFrame(moveRafId);
+            }
             document.removeEventListener("mousedown", handleMouseDown, true);
             document.removeEventListener("mousemove", handleMouseMove, true);
             document.removeEventListener("mouseup", handleMouseUp, true);
             document.removeEventListener("contextmenu", handleContextMenu, true);
         };
-    }, []);
+    }, [currentWindow]);
 
     // Native pointerup for drag exit — removed, now handled in enterDragMode
     // useEffect(() => {
@@ -417,11 +427,10 @@ export default function PetWindow() {
         // Disable pointer events on canvas after it's created
         const checkCanvas = setInterval(() => {
             const canvas = document.querySelector("canvas");
-            if (canvas) {
-                (canvas as HTMLCanvasElement).style.pointerEvents = "none";
-                console.log("[PetWindow] Canvas pointer events disabled");
-                clearInterval(checkCanvas);
-            }
+                if (canvas) {
+                    (canvas as HTMLCanvasElement).style.pointerEvents = "none";
+                    clearInterval(checkCanvas);
+                }
         }, 100);
 
         return () => {

--- a/src/windows/PetWindow.tsx
+++ b/src/windows/PetWindow.tsx
@@ -343,7 +343,7 @@ export default function PetWindow() {
             }
         };
 
-        const handleMouseUp = (e: MouseEvent) => {
+        const handleMouseUp = async (e: MouseEvent) => {
             if (e.button === 2) {
                 e.preventDefault();
                 e.stopPropagation();
@@ -353,12 +353,26 @@ export default function PetWindow() {
                     const pos = rightClickStartRef.current;
                     setContextMenu({ visible: true, x: pos.x, y: pos.y });
                 } else if (hasMoved && windowStartPos) {
-                    // Drag completed — save position
-                    currentWindow.outerPosition().then(pos => {
-                        invoke<PetConfig>("get_pet_config").then(cfg => {
-                            invoke("save_pet_config", {
-                                config: { ...cfg, position_x: pos.x, position_y: pos.y }
-                            }).catch(console.error);
+                    const dx = e.screenX - dragStartPos!.x;
+                    const dy = e.screenY - dragStartPos!.y;
+                    const finalX = windowStartPos.x + dx;
+                    const finalY = windowStartPos.y + dy;
+
+                    if (moveRafId !== null) {
+                        cancelAnimationFrame(moveRafId);
+                        moveRafId = null;
+                    }
+                    pendingWindowPos = null;
+
+                    try {
+                        await currentWindow.setPosition(new PhysicalPosition(finalX, finalY));
+                    } catch (err) {
+                        console.error("[PetWindow] Failed to finalize position:", err);
+                    }
+
+                    invoke<PetConfig>("get_pet_config").then(cfg => {
+                        invoke("save_pet_config", {
+                            config: { ...cfg, position_x: finalX, position_y: finalY }
                         }).catch(console.error);
                     }).catch(console.error);
                 }
@@ -552,6 +566,8 @@ export default function PetWindow() {
                 {configLoaded && <Live2DViewer
                     ref={viewerRef}
                     modelUrl={modelUrl}
+                    // Live2DViewer owns the chat-expression/chat-action subscriptions
+                    // and drives this shared controller directly.
                     controller={controllerRef.current}
                     backgroundAlpha={0}
                     displayMode="full"

--- a/src/windows/PetWindow.tsx
+++ b/src/windows/PetWindow.tsx
@@ -7,7 +7,6 @@ import { Live2DController } from "../features/live2d/Live2DController";
 import PetContextMenu from "../features/pet/PetContextMenu";
 import { usePetChat } from "../features/pet/usePetChat";
 import type { Live2DViewerHandle } from "../features/live2d/Live2DViewer";
-import type { EmotionState, ActionIntent } from "../features/live2d/Live2DController";
 import "../ui/i18n";
 import { live2dUrl } from "../lib/utils";
 
@@ -22,6 +21,7 @@ interface PetConfig {
     window_width: number;
     window_height: number;
     model_scale?: number;
+    render_fps?: number;
 }
 
 export default function PetWindow() {
@@ -61,6 +61,7 @@ export default function PetWindow() {
     const hasSavedSizeRef = useRef(false);
     const [configLoaded, setConfigLoaded] = useState(false);
     const [scaleMultiplier, setScaleMultiplier] = useState(1);
+    const [renderFps, setRenderFps] = useState(60);
     const { isStreaming, sendMessage } = usePetChat();
 
     // On mount: restore saved window size from config
@@ -74,10 +75,30 @@ export default function PetWindow() {
             const savedMultiplier = cfg.model_scale && cfg.model_scale > 0 ? cfg.model_scale : 1;
             userScaleMultiplierRef.current = savedMultiplier;
             setScaleMultiplier(savedMultiplier);
+            setRenderFps(typeof cfg.render_fps === "number" ? cfg.render_fps : 60);
             setConfigLoaded(true);
         }).catch(() => {
             setConfigLoaded(true); // 即使失败也要允许渲染
         });
+    }, []);
+
+    useEffect(() => {
+        const unlisten = listen<PetConfig>("pet-config-updated", (event) => {
+            const cfg = event.payload;
+
+            if (typeof cfg.model_scale === "number" && cfg.model_scale > 0) {
+                userScaleMultiplierRef.current = cfg.model_scale;
+                setScaleMultiplier(cfg.model_scale);
+            }
+
+            if (typeof cfg.render_fps === "number") {
+                setRenderFps(cfg.render_fps);
+            }
+        });
+
+        return () => {
+            unlisten.then(fn => fn()).catch(console.error);
+        };
     }, []);
 
     // Handle model loaded - auto-fit only on first launch (no saved size)
@@ -418,22 +439,6 @@ export default function PetWindow() {
         return () => { unlisten.then(fn => fn()); };
     }, []);
 
-    // Listen for chat-expression events
-    useEffect(() => {
-        const unlisten = listen<{ expression: string }>("chat-expression", (event) => {
-            controllerRef.current?.setEmotion(event.payload.expression as EmotionState);
-        });
-        return () => { unlisten.then(fn => fn()); };
-    }, []);
-
-    // Listen for chat-action events
-    useEffect(() => {
-        const unlisten = listen<{ action: string }>("chat-action", (event) => {
-            controllerRef.current?.playActionMotion(event.payload.action as ActionIntent);
-        });
-        return () => { unlisten.then(fn => fn()); };
-    }, []);
-
     // exitDragMode removed — now handled inline in long press handler
 
     const handleSendChat = useCallback(async () => {
@@ -544,6 +549,7 @@ export default function PetWindow() {
                     gazeTracking={true}
                     fixedSize={canvasSize || undefined}
                     scaleMultiplier={scaleMultiplier}
+                    maxFps={renderFps}
                     onModelLoaded={handleModelLoaded}
                 />}
             </div>


### PR DESCRIPTION
## Summary / 概述

Reduce unnecessary Live2D and pet-window CPU usage, it applies to both the main app and the floating pet window.

## Changes / 变更内容

- Stopped the audio analysis loop when playback pauses or ends to avoid idle CPU usage
- Added Live2D render FPS control with immediate effect and unified it across the main app and floating pet window
- Paused Live2D rendering when the page is hidden and cleaned up duplicate/temporary pet-window listeners
- Throttled pet-window dragging to one position update per animation frame and reused VAD buffers to reduce drag-time and voice-interrupt overhead

## Type / 类型

- [ ] `feat` — New feature / 新功能
- [x] `fix` — Bug fix / Bug 修复
- [ ] `refactor` — Code refactoring / 代码重构
- [ ] `docs` — Documentation / 文档
- [ ] `style` — UI/CSS changes / 界面样式
- [ ] `test` — Tests / 测试
- [ ] `chore` — Build/tooling / 构建工具

## Testing / 测试

- [x] `npm run tauri dev` runs without errors
- [x] `npx tsc --noEmit` passes
- [x] `cargo check` passes
- [x] Manually tested the feature

## Screenshots / 截图

N/A

## Related Issues / 相关 Issue

N/A
