### PR TITLE
feat: add edge tts backend and improve voice selection

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -102,6 +102,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +238,18 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -318,6 +380,28 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -807,10 +891,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -836,6 +966,24 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -1626,6 +1774,30 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "edge-tts-rust"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cc3d1bf1065a5a89973b193dd7bbc6cf6679b4607f2b5f5939400e289d6288"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "chrono",
+ "clap",
+ "futures-util",
+ "http 1.4.0",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "either"
@@ -3234,6 +3406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4295,6 +4473,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
@@ -7011,6 +7195,7 @@ dependencies = [
  "chrono",
  "cpal",
  "dirs-next",
+ "edge-tts-rust",
  "eventsource-stream",
  "fastembed",
  "filetime",
@@ -7718,7 +7903,23 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.28.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7860,13 +8061,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -7970,6 +8176,25 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -8212,6 +8437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8323,7 +8554,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "tokio-util",
  "tower-service",
  "tracing",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls", "multipart"] }
+edge-tts-rust = "0.1.2"
 eventsource-stream = "0.2"
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/src/tts/config.rs
+++ b/src-tauri/src/tts/config.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderConfig {
     pub id: String,
-    pub provider_type: String, // "openai", "local_vits", "local_rvc", "azure", "elevenlabs", "browser"
+    pub provider_type: String, // "openai", "edge_tts", "local_vits", "local_rvc", "azure", "elevenlabs", "browser"
     #[serde(default = "default_true")]
     pub enabled: bool,
 

--- a/src-tauri/src/tts/edge.rs
+++ b/src-tauri/src/tts/edge.rs
@@ -1,0 +1,244 @@
+use super::config::ProviderConfig;
+use super::interface::{
+    Gender, ProviderCapabilities, TtsEngine, TtsError, TtsParams, TtsProvider, VoiceProfile,
+};
+use async_trait::async_trait;
+use edge_tts_rust::{Boundary, EdgeTtsClient, SpeakOptions, SynthesisEvent, Voice};
+use futures::StreamExt;
+use std::collections::HashMap;
+use std::pin::Pin;
+
+const DEFAULT_EDGE_VOICE: &str = "zh-CN-XiaoyiNeural";
+
+pub struct EdgeTtsProvider {
+    client: EdgeTtsClient,
+    provider_id: String,
+    default_voice: String,
+    voices: Vec<VoiceProfile>,
+}
+
+impl EdgeTtsProvider {
+    pub async fn from_config(config: &ProviderConfig) -> Option<Self> {
+        let client = match EdgeTtsClient::new() {
+            Ok(client) => client,
+            Err(err) => {
+                eprintln!("[TTS] Failed to initialize edge-tts-rust client: {}", err);
+                return None;
+            }
+        };
+
+        let provider_id = config.id.clone();
+        let default_voice = config
+            .default_voice
+            .clone()
+            .unwrap_or_else(|| DEFAULT_EDGE_VOICE.to_string());
+
+        let voices = match client.list_voices().await {
+            Ok(voices) => {
+                let mapped = voices
+                    .into_iter()
+                    .map(|voice| map_voice_profile(&provider_id, voice))
+                    .collect::<Vec<_>>();
+                if mapped.is_empty() {
+                    vec![fallback_voice_profile(&provider_id, &default_voice)]
+                } else {
+                    mapped
+                }
+            }
+            Err(err) => {
+                eprintln!("[TTS] Failed to fetch Edge TTS voices: {}", err);
+                vec![fallback_voice_profile(&provider_id, &default_voice)]
+            }
+        };
+
+        Some(Self {
+            client,
+            provider_id,
+            default_voice,
+            voices,
+        })
+    }
+
+    fn normalize_voice_id(&self, raw_voice: &str) -> String {
+        normalize_voice_id(&self.provider_id, raw_voice)
+    }
+
+    fn build_options(&self, params: &TtsParams) -> SpeakOptions {
+        let voice = params
+            .voice
+            .as_deref()
+            .map(|voice| self.normalize_voice_id(voice))
+            .unwrap_or_else(|| self.default_voice.clone());
+
+        SpeakOptions {
+            voice,
+            rate: speed_to_rate(params.speed),
+            volume: "+0%".to_string(),
+            pitch: pitch_to_hz(params.pitch),
+            boundary: Boundary::Sentence,
+        }
+    }
+}
+
+#[async_trait]
+impl TtsProvider for EdgeTtsProvider {
+    fn id(&self) -> String {
+        self.provider_id.clone()
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            supports_streaming: true,
+            supports_emotions: false,
+            supports_speed: true,
+            supports_pitch: true,
+            supports_cloning: false,
+            supports_ssml: false,
+        }
+    }
+
+    fn voices(&self) -> Vec<VoiceProfile> {
+        self.voices.clone()
+    }
+
+    async fn is_available(&self) -> bool {
+        true
+    }
+
+    async fn synthesize(&self, text: &str, params: TtsParams) -> Result<Vec<u8>, TtsError> {
+        let options = self.build_options(&params);
+        let result = self
+            .client
+            .synthesize(text, options)
+            .await
+            .map_err(map_edge_error)?;
+        Ok(result.audio)
+    }
+
+    async fn synthesize_stream(
+        &self,
+        text: &str,
+        params: TtsParams,
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Result<Vec<u8>, TtsError>> + Send>>, TtsError>
+    {
+        let options = self.build_options(&params);
+        let stream = self
+            .client
+            .stream(text.to_string(), options)
+            .await
+            .map_err(map_edge_error)?;
+
+        let audio_stream = stream.filter_map(|event| async move {
+            match event {
+                Ok(SynthesisEvent::Audio(chunk)) => Some(Ok(chunk.to_vec())),
+                Ok(SynthesisEvent::Boundary(_)) => None,
+                Err(err) => Some(Err(map_edge_error(err))),
+            }
+        });
+
+        Ok(Box::pin(audio_stream))
+    }
+}
+
+fn map_voice_profile(provider_id: &str, voice: Voice) -> VoiceProfile {
+    let mut extra_params = HashMap::new();
+    if let Some(codec) = voice.suggested_codec.clone() {
+        extra_params.insert("suggested_codec".to_string(), codec);
+    }
+    if let Some(status) = voice.status.clone() {
+        extra_params.insert("status".to_string(), status);
+    }
+    if !voice.voice_tag.voice_personalities.is_empty() {
+        extra_params.insert(
+            "personalities".to_string(),
+            voice.voice_tag.voice_personalities.join(", "),
+        );
+    }
+    if !voice.voice_tag.content_categories.is_empty() {
+        extra_params.insert(
+            "content_categories".to_string(),
+            voice.voice_tag.content_categories.join(", "),
+        );
+    }
+
+    let short_name = voice.short_name;
+
+    VoiceProfile {
+        voice_id: format!("{}_{}", provider_id, short_name),
+        name: voice
+            .friendly_name
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or_else(|| short_name.clone()),
+        gender: parse_gender(&voice.gender),
+        language: voice.locale,
+        engine: TtsEngine::Cloud,
+        provider_id: provider_id.to_string(),
+        extra_params,
+    }
+}
+
+fn fallback_voice_profile(provider_id: &str, default_voice: &str) -> VoiceProfile {
+    VoiceProfile {
+        voice_id: format!("{}_{}", provider_id, default_voice),
+        name: default_voice.to_string(),
+        gender: Gender::Neutral,
+        language: "en-US".to_string(),
+        engine: TtsEngine::Cloud,
+        provider_id: provider_id.to_string(),
+        extra_params: HashMap::new(),
+    }
+}
+
+fn parse_gender(gender: &str) -> Gender {
+    match gender.to_ascii_lowercase().as_str() {
+        "male" => Gender::Male,
+        "female" => Gender::Female,
+        _ => Gender::Neutral,
+    }
+}
+
+fn speed_to_rate(speed: Option<f32>) -> String {
+    let delta = ((speed.unwrap_or(1.0).clamp(0.1, 3.0) - 1.0) * 100.0).round() as i32;
+    format!("{delta:+}%")
+}
+
+fn pitch_to_hz(pitch: Option<f32>) -> String {
+    let delta = ((pitch.unwrap_or(1.0).clamp(0.1, 3.0) - 1.0) * 100.0).round() as i32;
+    format!("{delta:+}Hz")
+}
+
+fn map_edge_error(err: edge_tts_rust::Error) -> TtsError {
+    TtsError::SynthesisFailed(format!("edge-tts-rust error: {}", err))
+}
+
+fn normalize_voice_id(provider_id: &str, raw_voice: &str) -> String {
+    raw_voice
+        .strip_prefix(&format!("{}_", provider_id))
+        .unwrap_or(raw_voice)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn speed_is_converted_to_signed_percent() {
+        assert_eq!(speed_to_rate(Some(1.5)), "+50%");
+        assert_eq!(speed_to_rate(Some(0.5)), "-50%");
+    }
+
+    #[test]
+    fn pitch_is_converted_to_signed_hz() {
+        assert_eq!(pitch_to_hz(Some(1.2)), "+20Hz");
+        assert_eq!(pitch_to_hz(Some(0.8)), "-20Hz");
+    }
+
+    #[test]
+    fn provider_prefix_is_removed_before_synthesis() {
+        assert_eq!(
+            normalize_voice_id("edge_tts", "edge_tts_zh-CN-XiaoyiNeural"),
+            "zh-CN-XiaoyiNeural"
+        );
+    }
+}

--- a/src-tauri/src/tts/manager.rs
+++ b/src-tauri/src/tts/manager.rs
@@ -2,6 +2,7 @@ use super::browser::BrowserTTSProvider;
 use super::cache::{CacheKey, TtsCache};
 use super::cloud_base::CloudTTSProvider;
 use super::config::{ProviderConfig, TtsSystemConfig};
+use super::edge::EdgeTtsProvider;
 use super::interface::{ProviderCapabilities, TtsError, TtsParams, TtsProvider, VoiceProfile};
 use super::local_gpt_sovits::LocalGPTSoVITSProvider;
 use super::local_rvc::LocalRVCProvider;
@@ -103,7 +104,7 @@ impl TtsService {
                 continue;
             }
 
-            match Self::build_provider(provider_config) {
+            match Self::build_provider(provider_config).await {
                 Some(provider) => {
                     println!("[TTS] Registering provider: {}", provider_config.id);
                     service.register_provider(provider).await;
@@ -121,11 +122,14 @@ impl TtsService {
     }
 
     /// Build a provider from config.
-    fn build_provider(config: &ProviderConfig) -> Option<Box<dyn TtsProvider>> {
+    async fn build_provider(config: &ProviderConfig) -> Option<Box<dyn TtsProvider>> {
         match config.provider_type.as_str() {
             "openai" => {
                 OpenAITtsProvider::from_config(config).map(|p| Box::new(p) as Box<dyn TtsProvider>)
             }
+            "edge_tts" => EdgeTtsProvider::from_config(config)
+                .await
+                .map(|p| Box::new(p) as Box<dyn TtsProvider>),
             "browser" => {
                 BrowserTTSProvider::from_config(config).map(|p| Box::new(p) as Box<dyn TtsProvider>)
             }
@@ -394,7 +398,7 @@ impl TtsService {
                 println!("[TTS] Skipping disabled provider: {}", provider_config.id);
                 continue;
             }
-            match Self::build_provider(provider_config) {
+            match Self::build_provider(provider_config).await {
                 Some(provider) => {
                     println!("[TTS] Registering provider: {}", provider_config.id);
                     self.register_provider(provider).await;

--- a/src-tauri/src/tts/mod.rs
+++ b/src-tauri/src/tts/mod.rs
@@ -2,6 +2,7 @@ pub mod browser;
 pub mod cache;
 pub mod cloud_base;
 pub mod config;
+pub mod edge;
 pub mod emotion_tts;
 pub mod interface;
 pub mod local_gpt_sovits;

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,71 +1,265 @@
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
+import { Search, ChevronDown, Check, X } from "lucide-react";
 
 export interface SelectOption {
     value: string;
     label: string;
     disabled?: boolean;
+    description?: string;
+}
+
+export interface SelectGroup {
+    label: string;
+    options: SelectOption[];
 }
 
 export interface SelectProps {
     value: string;
     onChange: (value: string) => void;
-    options: SelectOption[];
+    options: SelectOption[] | SelectGroup[];
     className?: string;
     disabled?: boolean;
     placeholder?: string;
+    searchable?: boolean;
+    searchPlaceholder?: string;
+    emptyMessage?: string;
 }
 
-const ChevronIcon = () => (
-    <svg
-        width="12"
-        height="12"
-        viewBox="0 0 12 12"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        className="pointer-events-none"
-    >
-        <path
-            d="M2 4L6 8L10 4"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-        />
-    </svg>
-);
-
 const Select = React.forwardRef<HTMLDivElement, SelectProps>(
-    ({ value, onChange, options, className, disabled, placeholder }, ref) => {
+    (
+        {
+            value,
+            onChange,
+            options,
+            className,
+            disabled,
+            placeholder,
+            searchable = false,
+            searchPlaceholder = "Search...",
+            emptyMessage = "No options found",
+        },
+        ref
+    ) => {
         const [open, setOpen] = React.useState(false);
         const [dropUp, setDropUp] = React.useState(false);
+        const [searchQuery, setSearchQuery] = React.useState("");
+        const [coords, setCoords] = React.useState({ top: 0, left: 0, width: 0 });
         const containerRef = React.useRef<HTMLDivElement>(null);
+        const searchInputRef = React.useRef<HTMLInputElement>(null);
 
         React.useImperativeHandle(ref, () => containerRef.current!);
 
+        const updateCoords = React.useCallback(() => {
+            if (containerRef.current) {
+                const rect = containerRef.current.getBoundingClientRect();
+                const spaceBelow = window.innerHeight - rect.bottom;
+                const shouldDropUp = spaceBelow < 300;
+                setDropUp(shouldDropUp);
+                setCoords({
+                    top: shouldDropUp ? rect.top : rect.bottom,
+                    left: rect.left,
+                    width: rect.width,
+                });
+            }
+        }, []);
+
+        React.useEffect(() => {
+            if (!open) {
+                setSearchQuery("");
+                return;
+            }
+
+            updateCoords();
+
+            if (!searchable) return;
+
+            const timer = window.setTimeout(() => {
+                searchInputRef.current?.focus();
+            }, 50);
+
+            return () => window.clearTimeout(timer);
+        }, [open, searchable, updateCoords]);
+
         React.useEffect(() => {
             if (!open) return;
+
             const handler = (e: MouseEvent) => {
                 if (!containerRef.current?.contains(e.target as Node)) {
-                    setOpen(false);
+                    const portal = document.getElementById("select-portal-root");
+                    if (!portal?.contains(e.target as Node)) {
+                        setOpen(false);
+                    }
                 }
             };
+
+            const scrollHandler = () => {
+                updateCoords();
+            };
+
             document.addEventListener("mousedown", handler);
-            return () => document.removeEventListener("mousedown", handler);
-        }, [open]);
+            window.addEventListener("scroll", scrollHandler, true);
+            window.addEventListener("resize", scrollHandler);
+
+            return () => {
+                document.removeEventListener("mousedown", handler);
+                window.removeEventListener("scroll", scrollHandler, true);
+                window.removeEventListener("resize", scrollHandler);
+            };
+        }, [open, updateCoords]);
 
         const handleToggle = () => {
             if (disabled) return;
-            if (!open && containerRef.current) {
-                const rect = containerRef.current.getBoundingClientRect();
-                const spaceBelow = window.innerHeight - rect.bottom;
-                setDropUp(spaceBelow < 220);
-            }
             setOpen(v => !v);
         };
 
-        const selected = options.find(o => o.value === value);
+        const isGrouped = (opts: SelectOption[] | SelectGroup[]): opts is SelectGroup[] => {
+            return opts.length > 0 && 'options' in opts[0];
+        };
+
+        const flatOptions = isGrouped(options) 
+            ? options.flatMap(g => g.options.map(o => ({ ...o, groupLabel: g.label })))
+            : options;
+
+        const selected = flatOptions.find(o => o.value === value);
         const displayLabel = selected?.label ?? placeholder ?? "";
+        const normalizedQuery = searchQuery.trim().toLowerCase();
+
+        const filteredGroups = React.useMemo(() => {
+            if (!searchable || !normalizedQuery) {
+                return isGrouped(options) ? options : [{ label: "", options }];
+            }
+
+            if (isGrouped(options)) {
+                return options
+                    .map(group => ({
+                        ...group,
+                        options: group.options.filter(opt =>
+                            opt.label.toLowerCase().includes(normalizedQuery) ||
+                            opt.value.toLowerCase().includes(normalizedQuery) ||
+                            (opt.description && opt.description.toLowerCase().includes(normalizedQuery))
+                        )
+                    }))
+                    .filter(group => group.options.length > 0);
+            } else {
+                return [{
+                    label: "",
+                    options: (options as SelectOption[]).filter(opt =>
+                        opt.label.toLowerCase().includes(normalizedQuery) ||
+                        opt.value.toLowerCase().includes(normalizedQuery) ||
+                        (opt.description && opt.description.toLowerCase().includes(normalizedQuery))
+                    )
+                }];
+            }
+        }, [options, searchable, normalizedQuery]);
+
+        const totalFilteredCount = filteredGroups.reduce((acc, g) => acc + g.options.length, 0);
+
+        const dropdownContent = (
+            <div
+                id="select-portal-root"
+                style={{
+                    position: "fixed",
+                    top: dropUp ? "auto" : `${coords.top + 8}px`,
+                    bottom: dropUp ? `${window.innerHeight - coords.top + 8}px` : "auto",
+                    left: `${coords.left}px`,
+                    width: `${coords.width}px`,
+                    maxHeight: "320px",
+                }}
+                className={cn(
+                    "z-[9999] overflow-hidden sticky-dropdown",
+                    "bg-[var(--color-bg-elevated)] border border-white/10",
+                    "rounded-xl leading-normal",
+                    "shadow-[0_12px_40px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.05)]",
+                    "animate-in fade-in zoom-in-95 duration-200"
+                )}
+            >
+                {searchable && (
+                    <div className="sticky top-0 z-10 bg-[var(--color-bg-elevated)] border-b border-white/5 p-2">
+                        <div className="relative group">
+                            <Search 
+                                size={14} 
+                                className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)] group-focus-within:text-[var(--color-accent)] transition-colors" 
+                            />
+                            <input
+                                ref={searchInputRef}
+                                type="text"
+                                value={searchQuery}
+                                onChange={(e) => setSearchQuery(e.target.value)}
+                                placeholder={searchPlaceholder}
+                                className={cn(
+                                    "w-full rounded-lg bg-white/5 pl-9 pr-8 py-2",
+                                    "text-xs text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)]/60",
+                                    "border border-white/5 focus:border-[var(--color-accent)]/50 focus:outline-none",
+                                    "transition-all"
+                                )}
+                            />
+                            {searchQuery && (
+                                <button
+                                    onClick={() => setSearchQuery("")}
+                                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-[var(--color-text-muted)] hover:text-white transition-colors"
+                                >
+                                    <X size={12} />
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                <div className="max-h-[300px] overflow-y-auto py-1 scrollbar-thin">
+                    {totalFilteredCount === 0 ? (
+                        <div className="px-4 py-8 text-center">
+                            <p className="text-xs text-[var(--color-text-muted)]">
+                                {emptyMessage}
+                            </p>
+                        </div>
+                    ) : (
+                        filteredGroups.map((group, gIdx) => (
+                            <React.Fragment key={group.label || gIdx}>
+                                {group.label && (
+                                    <div className="px-3 py-1.5 mt-1 text-[10px] font-bold text-[var(--color-text-muted)] uppercase tracking-widest bg-white/[0.02]">
+                                        {group.label}
+                                    </div>
+                                )}
+                                {group.options.map(opt => (
+                                    <div
+                                        key={opt.value}
+                                        onClick={() => {
+                                            if (!opt.disabled) {
+                                                onChange(opt.value);
+                                                setOpen(false);
+                                            }
+                                        }}
+                                        className={cn(
+                                            "mx-1 px-3 py-2 rounded-lg text-sm cursor-pointer",
+                                            "flex items-center justify-between gap-2",
+                                            "transition-all duration-150",
+                                            opt.value === value
+                                                ? "bg-[var(--color-accent)]/10 text-[var(--color-accent)] font-medium"
+                                                : "text-[var(--color-text-primary)] hover:bg-white/5",
+                                            opt.disabled && "opacity-40 cursor-not-allowed"
+                                        )}
+                                    >
+                                        <div className="flex flex-col min-w-0">
+                                            <span className="truncate">{opt.label}</span>
+                                            {opt.description && (
+                                                <span className="text-[10px] text-[var(--color-text-muted)] truncate">
+                                                    {opt.description}
+                                                </span>
+                                            )}
+                                        </div>
+                                        {opt.value === value && (
+                                            <Check size={14} className="shrink-0" />
+                                        )}
+                                    </div>
+                                ))}
+                            </React.Fragment>
+                        ))
+                    )}
+                </div>
+            </div>
+        );
 
         return (
             <div
@@ -78,65 +272,27 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>(
                     onClick={handleToggle}
                     className={cn(
                         "w-full flex items-center justify-between gap-2",
-                        "bg-black/40 border border-[var(--color-border)]",
-                        "text-[var(--color-text-primary)] text-sm font-body",
-                        "rounded-md px-4 py-3",
-                        "transition-all duration-150",
-                        "focus:outline-none focus:border-[var(--color-accent)] focus:shadow-[var(--glow-accent)]",
-                        open && "border-[var(--color-accent)] shadow-[var(--glow-accent)]",
+                        "bg-white/5 border border-[var(--color-border)]",
+                        "text-[var(--color-text-primary)] text-sm",
+                        "rounded-lg px-3 py-2.5",
+                        "transition-all duration-200",
+                        "hover:bg-white/10 hover:border-white/20",
+                        "focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]/50",
+                        open && "border-[var(--color-accent)]/50 bg-white/10",
                         disabled && "opacity-50 cursor-not-allowed",
-                        !disabled && "cursor-pointer hover:border-[var(--color-accent)]/60"
+                        !disabled && "cursor-pointer"
                     )}
                 >
-                    <span className={cn(!selected && "text-[var(--color-text-muted)]")}>
+                    <span className={cn("min-w-0 flex-1 truncate text-left", !selected && "text-[var(--color-text-muted)]")}>
                         {displayLabel}
                     </span>
-                    <span
-                        className={cn(
-                            "text-[var(--color-text-muted)] transition-transform duration-150",
-                            open && "rotate-180"
-                        )}
-                    >
-                        <ChevronIcon />
-                    </span>
+                    <ChevronDown 
+                        size={14} 
+                        className={cn("text-[var(--color-text-muted)] transition-transform duration-200", open && "rotate-180")} 
+                    />
                 </button>
 
-                {open && (
-                    <div
-                        className={cn(
-                            "absolute z-50 w-full",
-                            dropUp ? "bottom-full mb-1" : "top-full mt-1",
-                            "bg-[#0a0a1a] border border-[var(--color-accent)]/30",
-                            "rounded-md overflow-hidden",
-                            "shadow-[0_8px_32px_rgba(0,0,0,0.6),0_0_0_1px_rgba(0,240,255,0.05)]"
-                        )}
-                    >
-                        <ul className="max-h-52 overflow-y-auto py-1 scrollbar-thin">
-                            {options.map(opt => (
-                                <li
-                                    key={opt.value}
-                                    onClick={() => {
-                                        if (!opt.disabled) {
-                                            onChange(opt.value);
-                                            setOpen(false);
-                                        }
-                                    }}
-                                    className={cn(
-                                        "px-4 py-2.5 text-sm font-body cursor-pointer",
-                                        "transition-colors duration-100",
-                                        "text-[var(--color-text-primary)]",
-                                        opt.value === value
-                                            ? "bg-[var(--color-accent)]/15 text-[var(--color-accent)]"
-                                            : "hover:bg-white/5",
-                                        opt.disabled && "opacity-40 cursor-not-allowed"
-                                    )}
-                                >
-                                    {opt.label}
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                )}
+                {open && createPortal(dropdownContent, document.body)}
             </div>
         );
     }

--- a/src/ui/locales/en.json
+++ b/src/ui/locales/en.json
@@ -191,6 +191,9 @@
                 "browser": "BROWSER",
                 "voice": "Voice",
                 "no_voices": "No voices available",
+                "voice_search": "Search voice name, language, or ID",
+                "voice_no_match": "No matching voices",
+                "voice_count_hint": "{{count}} voices loaded. Use search in the dropdown.",
                 "speed": "Speed",
                 "pitch": "Pitch",
                 "test": "▶ Test Voice"

--- a/src/ui/locales/ja.json
+++ b/src/ui/locales/ja.json
@@ -191,6 +191,9 @@
                 "browser": "ブラウザ (Browser)",
                 "voice": "音声/声質",
                 "no_voices": "利用可能な音声がありません",
+                "voice_search": "音声名、言語、ID で検索",
+                "voice_no_match": "一致する音声がありません",
+                "voice_count_hint": "{{count}} 件の音声があります。ドロップダウン内で検索できます。",
                 "speed": "速度",
                 "pitch": "ピッチ",
                 "test": "▶ テスト発話"

--- a/src/ui/locales/ko.json
+++ b/src/ui/locales/ko.json
@@ -191,6 +191,9 @@
                 "browser": "브라우저 (Browser)",
                 "voice": "음성",
                 "no_voices": "사용 가능한 음성 없음",
+                "voice_search": "음성 이름, 언어 또는 ID 검색",
+                "voice_no_match": "일치하는 음성이 없습니다",
+                "voice_count_hint": "{{count}}개의 음성이 로드되었습니다. 드롭다운에서 검색할 수 있습니다.",
                 "speed": "속도",
                 "pitch": "피치",
                 "test": "▶ 음성 테스트"

--- a/src/ui/locales/zh.json
+++ b/src/ui/locales/zh.json
@@ -191,6 +191,9 @@
                 "browser": "浏览器自带 (Browser)",
                 "voice": "语音/音色",
                 "no_voices": "无可用语音",
+                "voice_search": "搜索语音名称、语言或 ID",
+                "voice_no_match": "没有匹配的语音",
+                "voice_count_hint": "已加载 {{count}} 个语音，可在下拉框中搜索",
                 "speed": "语速",
                 "pitch": "音调",
                 "test": "▶ 测试语音"

--- a/src/ui/widgets/SettingsPanel.tsx
+++ b/src/ui/widgets/SettingsPanel.tsx
@@ -122,6 +122,15 @@ function getDefaultTtsVoice(providerId: string, voices: VoiceProfile[]): string 
     return providerVoice?.voice_id || "";
 }
 
+function stripProviderVoiceId(providerId: string, voiceId: string): string {
+    return voiceId.startsWith(`${providerId}_`) ? voiceId.slice(providerId.length + 1) : voiceId;
+}
+
+function usesShortTtsVoiceId(providerId: string, ttsConfig?: TtsSystemConfig | null): boolean {
+    const provider = ttsConfig?.providers.find(p => p.id === providerId);
+    return provider?.provider_type === "edge_tts";
+}
+
 function normalizeTtsVoice(
     providerId: string,
     voice: string,
@@ -133,6 +142,16 @@ function normalizeTtsVoice(
             const provider = ttsConfig?.providers.find(p => p.id === providerId);
             return provider?.default_voice || "alloy";
         }
+
+        if (usesShortTtsVoiceId(providerId, ttsConfig)) {
+            const provider = ttsConfig?.providers.find(p => p.id === providerId);
+            if (provider?.default_voice) {
+                return provider.default_voice;
+            }
+            const providerVoice = voices.find(v => v.provider_id === providerId);
+            return providerVoice ? stripProviderVoiceId(providerId, providerVoice.voice_id) : "";
+        }
+
         return getDefaultTtsVoice(providerId, voices);
     }
 
@@ -144,11 +163,26 @@ function normalizeTtsVoice(
         return voice;
     }
 
-    const matchesProvider = voices.some(
-        v => v.provider_id === providerId && v.voice_id === voice
-    );
+    const matchesProvider = voices.some(v => {
+        if (v.provider_id !== providerId) return false;
+        if (usesShortTtsVoiceId(providerId, ttsConfig)) {
+            return stripProviderVoiceId(providerId, v.voice_id) === voice;
+        }
+        return v.voice_id === voice;
+    });
 
-    return matchesProvider ? voice : getDefaultTtsVoice(providerId, voices);
+    if (matchesProvider) {
+        return voice;
+    }
+
+    if (usesShortTtsVoiceId(providerId, ttsConfig)) {
+        const provider = ttsConfig?.providers.find(p => p.id === providerId);
+        if (provider?.default_voice) {
+            return provider.default_voice;
+        }
+    }
+
+    return getDefaultTtsVoice(providerId, voices);
 }
 
 export default function SettingsPanel({ isOpen, onClose, backgroundControls, displayMode, onDisplayModeChange, customModelPath, onCustomModelChange, gazeTracking: gazeTrackingProp, onGazeTrackingChange, renderFps, onRenderFpsChange, sttConfig: sttConfigProp, voiceInterrupt: _voiceInterruptProp, imageGenConfig: imageGenConfigProp, telegramConfig: _telegramConfigProp, onVisionConfigChange }: SettingsPanelProps) {
@@ -359,8 +393,25 @@ export default function SettingsPanel({ isOpen, onClose, backgroundControls, dis
 
         // Persist TTS Config
         if (localTtsConfig) {
+            const ttsConfigToSave: TtsSystemConfig = {
+                ...localTtsConfig,
+                providers: localTtsConfig.providers.map((provider) => {
+                    if (
+                        provider.id === ttsProviderId
+                        && (provider.provider_type === "openai" || provider.provider_type === "edge_tts")
+                    ) {
+                        return {
+                            ...provider,
+                            default_voice: ttsVoice || null,
+                        };
+                    }
+                    return provider;
+                }),
+            };
+
             try {
-                await saveTtsConfig(localTtsConfig);
+                await saveTtsConfig(ttsConfigToSave);
+                setLocalTtsConfig(ttsConfigToSave);
                 // Refresh provider status after saving config
                 const [providers, voices] = await Promise.all([
                     listTtsProviders(),

--- a/src/ui/widgets/settings/TtsTab.tsx
+++ b/src/ui/widgets/settings/TtsTab.tsx
@@ -4,7 +4,7 @@
  *
  * Extracted from SettingsPanel lines 502–798.
  */
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { clsx } from "clsx";
 import { Trash2, RefreshCw } from "lucide-react";
@@ -15,6 +15,9 @@ import { synthesize, listGptSovitsModels } from "../../../lib/kokoro-bridge";
 import type { GptSovitsModels } from "../../../lib/kokoro-bridge";
 import type { ProviderStatus, VoiceProfile, TtsSystemConfig } from "../../../lib/kokoro-bridge";
 import type { ProviderConfigData } from "../../../core/types/mod";
+
+const stripProviderVoiceId = (providerId: string, voiceId: string) =>
+    voiceId.startsWith(`${providerId}_`) ? voiceId.slice(providerId.length + 1) : voiceId;
 
 export interface TtsTabProps {
     ttsConfig: TtsSystemConfig | null;
@@ -52,12 +55,57 @@ export default function TtsTab({
     const isActiveGptSovits = activeProvider?.provider_type === "gpt_sovits";
     const isActiveOpenAI = activeProvider?.provider_type === "openai";
     const activeVoices = voices.filter(v => v.provider_id === ttsProviderId);
-    const activeVoiceOptions = activeVoices.length === 0
-        ? [{ value: "", label: t("settings.tts.active_settings.no_voices") }]
-        : activeVoices.map(v => ({
-            value: v.voice_id,
-            label: `${v.name} (${v.gender} · ${v.language})`,
+    const shouldUseShortVoiceId = useCallback((providerId: string) => {
+        const provider = ttsConfig?.providers.find(p => p.id === providerId);
+        return provider?.provider_type === "openai" || provider?.provider_type === "edge_tts";
+    }, [ttsConfig]);
+
+    const toVoiceOptionValue = useCallback((providerId: string, voiceId: string) => {
+        return shouldUseShortVoiceId(providerId)
+            ? stripProviderVoiceId(providerId, voiceId)
+            : voiceId;
+    }, [shouldUseShortVoiceId]);
+
+    // Helper to get grouped voice options for any provider
+    const getVoiceOptions = useCallback((providerId: string, voiceList: VoiceProfile[]) => {
+        const filtered = voiceList.filter(v => v.provider_id === providerId);
+        if (filtered.length === 0) {
+            return [{ value: "", label: t("settings.tts.active_settings.no_voices") }];
+        }
+
+        const languages = new Set(filtered.map(v => v.language).filter(l => l && l !== "unknown"));
+        const shouldGroup = ttsConfig?.providers.find(p => p.id === providerId)?.provider_type === "edge_tts" || languages.size > 1;
+
+        if (shouldGroup) {
+            const groups: Record<string, VoiceProfile[]> = {};
+            filtered.forEach(v => {
+                const lang = v.language || "Other";
+                if (!groups[lang]) groups[lang] = [];
+                groups[lang].push(v);
+            });
+
+            return Object.entries(groups)
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([lang, items]) => ({
+                    label: lang.toUpperCase(),
+                    options: items.map(v => ({
+                        value: toVoiceOptionValue(providerId, v.voice_id),
+                        label: v.name,
+                        description: `${v.gender} · ${v.engine}`
+                    }))
+                }));
+        }
+
+        return filtered.map(v => ({
+            value: toVoiceOptionValue(providerId, v.voice_id),
+            label: v.name,
+            description: v.language ? `${v.gender} · ${v.language}` : v.gender
         }));
+    }, [t, toVoiceOptionValue, ttsConfig]);
+
+    // Simple memo for active settings voices
+    const activeVoiceOptions = useMemo(() => getVoiceOptions(ttsProviderId, voices), [ttsProviderId, voices, getVoiceOptions]);
+    const isVoiceSearchable = activeVoices.length > 8;
 
     // Scan for GPT-SoVITS models when install_path changes
     const scanModels = useCallback(async (providerId: string, installPath: string) => {
@@ -114,17 +162,8 @@ export default function TtsTab({
     const updateProviderConfig = (index: number, update: Partial<ProviderConfigData>) => {
         if (!ttsConfig) return;
         const newProviders = [...ttsConfig.providers];
-        const previousProvider = newProviders[index];
-        newProviders[index] = { ...previousProvider, ...update };
+        newProviders[index] = { ...newProviders[index], ...update };
         onTtsConfigChange({ ...ttsConfig, providers: newProviders });
-
-        if (
-            previousProvider.id === ttsProviderId &&
-            previousProvider.provider_type === "openai" &&
-            update.default_voice !== undefined
-        ) {
-            onTtsVoiceChange(update.default_voice || "");
-        }
     };
 
     const removeProvider = (index: number) => {
@@ -137,6 +176,7 @@ export default function TtsTab({
             setEditingProviderId(null);
         }
     };
+
 
     return (
         <div className="space-y-6">
@@ -196,11 +236,16 @@ export default function TtsTab({
                                 className={clsx(inputClasses, "font-mono text-xs")}
                             />
                         ) : (
-                            <Select
-                                value={ttsVoice}
-                                onChange={onTtsVoiceChange}
-                                options={activeVoiceOptions}
-                            />
+                            <div className="space-y-2">
+                                <Select
+                                    value={ttsVoice}
+                                    onChange={onTtsVoiceChange}
+                                    options={activeVoiceOptions}
+                                    searchable={isVoiceSearchable}
+                                    searchPlaceholder={t("settings.tts.active_settings.voice_search")}
+                                    emptyMessage={t("settings.tts.active_settings.voice_no_match")}
+                                />
+                            </div>
                         )}
                     </div>
                 )}
@@ -539,15 +584,17 @@ export default function TtsTab({
                                             </div>
                                         )}
 
-                                        {provider.provider_type === "openai" && (
+                                        {(provider.provider_type === "openai" || provider.provider_type === "edge_tts") && provider.id !== ttsProviderId && (
                                             <div>
                                                 <label className={labelClasses}>{t("settings.tts.active_settings.voice")}</label>
-                                                <input
-                                                    type="text"
+                                                <Select
                                                     value={provider.default_voice || ""}
-                                                    onChange={e => updateProviderConfig(index, { default_voice: e.target.value })}
-                                                    placeholder="alloy"
-                                                    className={clsx(inputClasses, "font-mono text-xs")}
+                                                    onChange={v => updateProviderConfig(index, { default_voice: v })}
+                                                    options={getVoiceOptions(provider.id, voices)}
+                                                    searchable={voices.filter(v => v.provider_id === provider.id).length > 8}
+                                                    placeholder={provider.provider_type === "edge_tts" ? "zh-CN-XiaoyiNeural" : "alloy"}
+                                                    searchPlaceholder={t("settings.tts.active_settings.voice_search")}
+                                                    emptyMessage={t("settings.tts.active_settings.voice_no_match")}
                                                 />
                                             </div>
                                         )}
@@ -579,7 +626,7 @@ export default function TtsTab({
                 {/* Add Provider Dropdown */}
                 <div className="pt-2">
                     <div className="grid grid-cols-2 gap-2">
-                        {["openai", "local_vits", "gpt_sovits", "azure", "elevenlabs"].map(type => (
+                        {["openai", "edge_tts", "local_vits", "gpt_sovits", "azure", "elevenlabs"].map(type => (
                             <button
                                 key={type}
                                 onClick={() => addProvider(type)}


### PR DESCRIPTION
## Summary / 概述

Add an Edge TTS backend powered by `edge-tts-rust` and improve the TTS voice selection UX. This also sets the default Edge voice to `zh-CN-XiaoyiNeural`.

## Changes / 变更内容

- Add a new Rust `edge_tts` backend using `edge-tts-rust`, including voice list loading, streaming synthesis, and default/fallback voice handling
- Improve the TTS settings UI with searchable voice selection for large voice lists and better select behavior
- Align current-provider voice editing with the existing TTS settings flow so the active voice is configured from `Current Settings` and persisted back on save
- Set the default Edge voice to `zh-CN-XiaoyiNeural`

## Type / 类型

- [x] `feat` — New feature / 新功能
- [ ] `fix` — Bug fix / Bug 修复
- [ ] `refactor` — Code refactoring / 代码重构
- [ ] `docs` — Documentation / 文档
- [x] `style` — UI/CSS changes / 界面样式
- [ ] `test` — Tests / 测试
- [ ] `chore` — Build/tooling / 构建工具

## Testing / 测试

- [x] `npm run tauri dev` runs without errors
- [x] `npx tsc --noEmit` passes
- [x] `cargo check` passes
- [x] Manually tested the feature


## Screenshots / 截图

<!-- If applicable / 如有需要 -->

## Related Issues / 相关 Issue

<!-- e.g. Closes #123 / 例如 Closes #123 -->
