### PR TITLE
fix: restore Codex Runtime conversation history

### DIFF
--- a/src-tauri/src/llm/codex_runtime_protocol.rs
+++ b/src-tauri/src/llm/codex_runtime_protocol.rs
@@ -281,12 +281,30 @@ fn normalize_history_item(mut item: Value, tools: &[LlmToolDefinition]) -> Resul
         return Ok(item);
     }
     if item.get("role").and_then(Value::as_str).is_some() {
+        let role = item
+            .get("role")
+            .and_then(Value::as_str)
+            .expect("role was checked above")
+            .to_string();
         item["type"] = Value::String("message".to_string());
         if let Some(Value::String(text)) = item.get("content").cloned() {
+            let content_type = if role == "assistant" {
+                "output_text"
+            } else {
+                "input_text"
+            };
             item["content"] = json!([{
-                "type": "input_text",
+                "type": content_type,
                 "text": text,
             }]);
+        } else if role == "assistant" {
+            if let Some(Value::Array(parts)) = item.get_mut("content") {
+                for part in parts {
+                    if part.get("type").and_then(Value::as_str) == Some("input_text") {
+                        part["type"] = Value::String("output_text".to_string());
+                    }
+                }
+            }
         }
         return Ok(item);
     }

--- a/src-tauri/src/llm/codex_runtime_protocol.rs
+++ b/src-tauri/src/llm/codex_runtime_protocol.rs
@@ -790,7 +790,7 @@ mod tests {
         assert_eq!(inputs.history[1]["content"][0]["type"], "input_text");
         assert_eq!(inputs.history[1]["type"], "message");
         assert_eq!(inputs.history[2]["content"][0]["text"], "answer");
-        assert_eq!(inputs.history[2]["content"][0]["type"], "input_text");
+        assert_eq!(inputs.history[2]["content"][0]["type"], "output_text");
         assert_eq!(inputs.history[2]["type"], "message");
         assert_eq!(
             inputs.turn_input,

--- a/src-tauri/src/llm/responses_protocol.rs
+++ b/src-tauri/src/llm/responses_protocol.rs
@@ -151,6 +151,12 @@ fn convert_content(role: &str, content: Option<&Value>) -> Result<Value, String>
     };
 
     if let Some(text) = content.as_str() {
+        if role == "assistant" && !text.is_empty() {
+            return Ok(json!([{
+                "type": "output_text",
+                "text": text,
+            }]));
+        }
         return Ok(Value::String(text.to_string()));
     }
 
@@ -166,7 +172,12 @@ fn convert_content(role: &str, content: Option<&Value>) -> Result<Value, String>
         match object.get("type").and_then(Value::as_str) {
             Some("text") => {
                 if let Some(text) = object.get("text").and_then(Value::as_str) {
-                    converted.push(json!({ "type": "input_text", "text": text }));
+                    let content_type = if role == "assistant" {
+                        "output_text"
+                    } else {
+                        "input_text"
+                    };
+                    converted.push(json!({ "type": content_type, "text": text }));
                 }
             }
             Some("image_url") => {
@@ -293,6 +304,26 @@ mod tests {
         assert_eq!(request["max_output_tokens"], 128);
         assert_eq!(request["input"][0]["role"], "system");
         assert_eq!(request["input"][1]["content"], "hello");
+    }
+
+    #[test]
+    fn encodes_assistant_text_as_output_text_for_responses_history() {
+        let request = build_responses_request(
+            "gpt-4o",
+            vec![
+                user_text_message("hello").into(),
+                crate::llm::messages::assistant_text_message("hi").into(),
+            ],
+            None,
+            vec![],
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(request["input"][0]["content"], "hello");
+        assert_eq!(request["input"][1]["role"], "assistant");
+        assert_eq!(request["input"][1]["content"][0]["type"], "output_text");
+        assert_eq!(request["input"][1]["content"][0]["text"], "hi");
     }
 
     #[test]

--- a/src-tauri/src/llm/responses_protocol.rs
+++ b/src-tauri/src/llm/responses_protocol.rs
@@ -151,12 +151,6 @@ fn convert_content(role: &str, content: Option<&Value>) -> Result<Value, String>
     };
 
     if let Some(text) = content.as_str() {
-        if role == "assistant" && !text.is_empty() {
-            return Ok(json!([{
-                "type": "output_text",
-                "text": text,
-            }]));
-        }
         return Ok(Value::String(text.to_string()));
     }
 
@@ -172,12 +166,7 @@ fn convert_content(role: &str, content: Option<&Value>) -> Result<Value, String>
         match object.get("type").and_then(Value::as_str) {
             Some("text") => {
                 if let Some(text) = object.get("text").and_then(Value::as_str) {
-                    let content_type = if role == "assistant" {
-                        "output_text"
-                    } else {
-                        "input_text"
-                    };
-                    converted.push(json!({ "type": content_type, "text": text }));
+                    converted.push(json!({ "type": "input_text", "text": text }));
                 }
             }
             Some("image_url") => {
@@ -307,7 +296,7 @@ mod tests {
     }
 
     #[test]
-    fn encodes_assistant_text_as_output_text_for_responses_history() {
+    fn keeps_assistant_text_in_the_shared_responses_request_shape() {
         let request = build_responses_request(
             "gpt-4o",
             vec![
@@ -322,8 +311,7 @@ mod tests {
 
         assert_eq!(request["input"][0]["content"], "hello");
         assert_eq!(request["input"][1]["role"], "assistant");
-        assert_eq!(request["input"][1]["content"][0]["type"], "output_text");
-        assert_eq!(request["input"][1]["content"][0]["text"], "hi");
+        assert_eq!(request["input"][1]["content"], "hi");
     }
 
     #[test]

--- a/src-tauri/src/llm/service.rs
+++ b/src-tauri/src/llm/service.rs
@@ -260,6 +260,9 @@ fn try_provider_by_id(
 }
 
 fn normalize_config(mut config: LlmConfig) -> LlmConfig {
+    for provider in &mut config.providers {
+        normalize_provider_identity(provider);
+    }
     normalize_provider_selection(
         &mut config.active_provider,
         &mut config.system_provider,
@@ -267,6 +270,9 @@ fn normalize_config(mut config: LlmConfig) -> LlmConfig {
     );
 
     for preset in &mut config.presets {
+        for provider in &mut preset.providers {
+            normalize_provider_identity(provider);
+        }
         normalize_preset(preset);
     }
 
@@ -309,6 +315,21 @@ fn normalize_provider_selection(
         } else {
             *system_provider = None;
         }
+    }
+}
+
+fn normalize_provider_identity(provider: &mut LlmProviderConfig) {
+    if provider.id == "codex-runtime" && provider.provider_type != "codex_runtime" {
+        tracing::warn!(
+            target: "llm",
+            "Repairing stale Codex Runtime provider identity (stored type: {})",
+            provider.provider_type
+        );
+        provider.provider_type = "codex_runtime".to_string();
+        provider.api_key = None;
+        provider.api_key_env = None;
+        provider.base_url = None;
+        provider.model = None;
     }
 }
 
@@ -914,6 +935,53 @@ mod tests {
                 .unwrap()
                 .enabled
         );
+
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[tokio::test]
+    async fn from_config_repairs_stale_codex_runtime_provider_identity() {
+        let config_path = temp_config_path("llm_config_repairs_stale_codex_runtime");
+        let config = LlmConfig {
+            active_provider: "codex-runtime".to_string(),
+            system_provider: None,
+            system_model: None,
+            providers: vec![LlmProviderConfig {
+                id: "codex-runtime".to_string(),
+                provider_type: "ollama".to_string(),
+                enabled: true,
+                supports_native_tools: true,
+                api_key: None,
+                api_key_env: None,
+                base_url: Some("http://localhost:11434".to_string()),
+                model: Some("llama3".to_string()),
+                extra: std::collections::HashMap::new(),
+            }],
+            presets: vec![],
+        };
+
+        let service = LlmService::from_config(config, config_path.clone());
+        let normalized = service.config().await;
+        let provider = normalized
+            .providers
+            .iter()
+            .find(|provider| provider.id == "codex-runtime")
+            .expect("Codex Runtime provider should remain configured");
+
+        assert_eq!(provider.provider_type, "codex_runtime");
+        assert!(provider.base_url.is_none());
+        assert!(provider.model.is_none());
+        assert_eq!(service.provider().await.id(), "codex-runtime");
+
+        let persisted = crate::llm::llm_config::load_config(&config_path);
+        let persisted_provider = persisted
+            .providers
+            .iter()
+            .find(|provider| provider.id == "codex-runtime")
+            .expect("repaired provider should be persisted");
+        assert_eq!(persisted_provider.provider_type, "codex_runtime");
+        assert!(persisted_provider.base_url.is_none());
+        assert!(persisted_provider.model.is_none());
 
         let _ = std::fs::remove_file(config_path);
     }

--- a/src/features/onboarding/provider-setup-core.test.ts
+++ b/src/features/onboarding/provider-setup-core.test.ts
@@ -72,6 +72,34 @@ describe("provider setup functional core", () => {
       .toBe("ollama");
   });
 
+  test("creates a canonical Ollama provider when the only provider has a stale Codex ID", () => {
+    const staleProvider: LlmProviderConfig = {
+      ...createProvider("ollama", []),
+      id: "codex-runtime",
+    };
+    const config: LlmConfig = {
+      active_provider: "codex-runtime",
+      providers: [staleProvider],
+      presets: [],
+    };
+
+    const updated = applyProviderSetupToConfig(config, {
+      providerType: "ollama",
+      presetId: null,
+      endpoint: "http://localhost:11434",
+      apiKey: null,
+      model: "llama3",
+    });
+
+    expect(updated.active_provider).toBe("ollama");
+    expect(updated.providers).toContainEqual(expect.objectContaining({
+      id: "ollama",
+      provider_type: "ollama",
+      base_url: "http://localhost:11434",
+      model: "llama3",
+    }));
+  });
+
   test("repairs a stale Codex runtime provider when selected again", () => {
     const staleProvider: LlmProviderConfig = {
       ...createProvider("ollama", []),

--- a/src/features/onboarding/provider-setup-core.test.ts
+++ b/src/features/onboarding/provider-setup-core.test.ts
@@ -47,4 +47,58 @@ describe("provider setup functional core", () => {
     expect(runtime).not.toHaveProperty("api_key");
     expect(runtime).not.toHaveProperty("base_url");
   });
+
+  test("does not reuse a stale Codex runtime ID for Ollama", () => {
+    const staleCodexId = {
+      ...createProvider("ollama", []),
+      id: "codex-runtime",
+    };
+    const config: LlmConfig = {
+      active_provider: "codex-runtime",
+      providers: [staleCodexId, createProvider("ollama", [staleCodexId])],
+      presets: [],
+    };
+
+    const updated = applyProviderSetupToConfig(config, {
+      providerType: "ollama",
+      presetId: null,
+      endpoint: "http://localhost:11434",
+      apiKey: null,
+      model: "llama3",
+    });
+
+    expect(updated.active_provider).toBe("ollama");
+    expect(updated.providers.find((provider) => provider.id === "codex-runtime")?.provider_type)
+      .toBe("ollama");
+  });
+
+  test("repairs a stale Codex runtime provider when selected again", () => {
+    const staleProvider: LlmProviderConfig = {
+      ...createProvider("ollama", []),
+      id: "codex-runtime",
+    };
+    const config: LlmConfig = {
+      active_provider: "codex-runtime",
+      providers: [staleProvider],
+      presets: [],
+    };
+
+    const updated = applyProviderSetupToConfig(config, {
+      providerType: "codex_runtime",
+      presetId: null,
+      endpoint: "",
+      apiKey: null,
+      model: "",
+    });
+    const runtime = updated.providers.find((provider) => provider.id === "codex-runtime");
+
+    expect(updated.active_provider).toBe("codex-runtime");
+    expect(runtime).toMatchObject({
+      id: "codex-runtime",
+      provider_type: "codex_runtime",
+      supports_native_tools: true,
+    });
+    expect(runtime?.base_url).toBeUndefined();
+    expect(runtime?.model).toBeUndefined();
+  });
 });

--- a/src/features/onboarding/provider-setup-core.ts
+++ b/src/features/onboarding/provider-setup-core.ts
@@ -213,7 +213,7 @@ function findProviderIndexForSetup(
     if (canonicalIndex >= 0) return canonicalIndex;
 
     const matchingTypeIndex = config.providers.findIndex(
-        (provider) => provider.provider_type === providerType && getCanonicalProviderType(provider.id) !== providerType,
+        (provider) => provider.provider_type === providerType && getCanonicalProviderType(provider.id) === null,
     );
     if (matchingTypeIndex >= 0) return matchingTypeIndex;
 

--- a/src/features/onboarding/provider-setup-core.ts
+++ b/src/features/onboarding/provider-setup-core.ts
@@ -149,19 +149,80 @@ function isSupportedProviderType(value: string): value is SupportedProviderType 
         || value === "codex_runtime";
 }
 
-function buildProviderId(providerType: SupportedProviderType, providers: ReadonlyArray<LlmProviderConfig>): string {
-    const baseId = providerType === "llama_cpp"
+function getBaseProviderId(providerType: SupportedProviderType): string {
+    return providerType === "llama_cpp"
             ? "llama-cpp"
         : providerType === "openai_responses"
             ? "openai-responses"
             : providerType === "codex_runtime"
                 ? "codex-runtime"
                 : providerType;
+}
+
+function getCanonicalProviderType(providerId: string): SupportedProviderType | null {
+    switch (providerId) {
+        case "openai":
+            return "openai";
+        case "openai-responses":
+            return "openai_responses";
+        case "anthropic":
+            return "anthropic";
+        case "ollama":
+            return "ollama";
+        case "llama-cpp":
+            return "llama_cpp";
+        case "codex-runtime":
+            return "codex_runtime";
+        default:
+            return null;
+    }
+}
+
+function buildProviderId(providerType: SupportedProviderType, providers: ReadonlyArray<LlmProviderConfig>): string {
+    const baseId = getBaseProviderId(providerType);
     if (!providers.some((provider) => provider.id === baseId)) return baseId;
 
     let suffix = 2;
     while (providers.some((provider) => provider.id === `${baseId}-${suffix}`)) suffix += 1;
     return `${baseId}-${suffix}`;
+}
+
+function findProviderIndexForSetup(
+    config: Readonly<LlmConfig>,
+    providerType: SupportedProviderType,
+): number {
+    const activeIndex = config.providers.findIndex((provider) => provider.id === config.active_provider);
+    const active = activeIndex >= 0 ? config.providers[activeIndex] : undefined;
+    const activeCanonicalType = active ? getCanonicalProviderType(active.id) : null;
+
+    // Keep custom provider IDs stable when the selected type already matches.
+    // A canonical ID with a different type is treated as stale instead of being
+    // silently reused for the wrong provider (e.g. codex-runtime as Ollama).
+    if (
+        active
+        && active.provider_type === providerType
+        && (activeCanonicalType === null || activeCanonicalType === providerType)
+    ) {
+        return activeIndex;
+    }
+
+    const canonicalId = getBaseProviderId(providerType);
+    const canonicalIndex = config.providers.findIndex(
+        (provider) => provider.id === canonicalId && provider.provider_type === providerType,
+    );
+    if (canonicalIndex >= 0) return canonicalIndex;
+
+    const matchingTypeIndex = config.providers.findIndex(
+        (provider) => provider.provider_type === providerType && getCanonicalProviderType(provider.id) !== providerType,
+    );
+    if (matchingTypeIndex >= 0) return matchingTypeIndex;
+
+    // Repair a stale built-in provider in place when the user selects its
+    // canonical type again, preserving the provider ID and all references.
+    const staleCanonicalIndex = config.providers.findIndex((provider) => provider.id === canonicalId);
+    if (staleCanonicalIndex >= 0) return staleCanonicalIndex;
+
+    return -1;
 }
 
 /** Creates a provider with focused-setup defaults. */
@@ -218,9 +279,8 @@ export function applyProviderSetupToConfig(
     setup: Readonly<ProviderSetup>,
 ): LlmConfig {
     const normalized = normalizeProviderSetup(setup);
-    const activeIndex = config.providers.findIndex((provider) => provider.id === config.active_provider);
-    const providerIndex = activeIndex >= 0 ? activeIndex : 0;
-    const existing = config.providers[providerIndex];
+    const providerIndex = findProviderIndexForSetup(config, normalized.providerType);
+    const existing = providerIndex >= 0 ? config.providers[providerIndex] : undefined;
     const fallback = existing ?? createProvider(normalized.providerType, config.providers);
     const provider: LlmProviderConfig = {
         ...fallback,
@@ -237,7 +297,9 @@ export function applyProviderSetupToConfig(
     };
     const providers = config.providers.length === 0
         ? [provider]
-        : config.providers.map((candidate, index) => index === providerIndex ? provider : candidate);
+        : providerIndex >= 0
+            ? config.providers.map((candidate, index) => index === providerIndex ? provider : candidate)
+            : [...config.providers, provider];
     return {
         ...config,
         active_provider: provider.id,


### PR DESCRIPTION
Fix the complete Codex Runtime no-response path. Codex history injection now converts assistant message content to output_text only inside codex_runtime_protocol, while the shared OpenAI Responses request translator keeps its input-compatible shape. Provider setup now reuses only truly custom provider IDs, so a single stale codex-runtime provider creates canonical Ollama instead of being normalized back to Codex Runtime. No database or migration changes. Validation: cargo test llm:: (68 passed), npm test -- --run (624 passed), npm run build (passed), IPC contract check (171 commands passed), and upstream/main merged without conflicts.