### PR TITLE
Fix stale WAV playback after stopping audio

### DIFF
--- a/src/lib/audio-player.test.ts
+++ b/src/lib/audio-player.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 type SetupResult = {
   decodeAudioDataMock: ReturnType<typeof vi.fn>;
   isTypeSupportedMock: ReturnType<typeof vi.fn>;
+  sources: AudioBufferSourceNode[];
 };
 
 function setupAudioEnvironment(): SetupResult {
@@ -11,6 +12,7 @@ function setupAudioEnvironment(): SetupResult {
 
   const decodeAudioDataMock = vi.fn().mockResolvedValue({ duration: 1 });
   const isTypeSupportedMock = vi.fn().mockReturnValue(true);
+  const sources: AudioBufferSourceNode[] = [];
 
   const analyser = {
     fftSize: 0,
@@ -52,7 +54,7 @@ function setupAudioEnvironment(): SetupResult {
     }
 
     createBufferSource() {
-      return {
+      const source = {
         buffer: null,
         connect: vi.fn(),
         disconnect: vi.fn(),
@@ -60,6 +62,8 @@ function setupAudioEnvironment(): SetupResult {
         stop: vi.fn(),
         onended: null,
       } as unknown as AudioBufferSourceNode;
+      sources.push(source);
+      return source;
     }
 
     resume = vi.fn().mockResolvedValue(undefined);
@@ -94,6 +98,7 @@ function setupAudioEnvironment(): SetupResult {
   return {
     decodeAudioDataMock,
     isTypeSupportedMock,
+    sources,
   };
 }
 
@@ -103,6 +108,84 @@ describe("AudioStreamManager format routing", () => {
   beforeEach(() => {
     vi.resetModules();
     env = setupAudioEnvironment();
+  });
+
+  const wavChunk = new Uint8Array([
+    0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00,
+    0x57, 0x41, 0x56, 0x45,
+  ]);
+
+  function deferDecode() {
+    let resolve!: (buffer: AudioBuffer) => void;
+    let reject!: (error: Error) => void;
+    env.decodeAudioDataMock.mockImplementationOnce(() => new Promise<AudioBuffer>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    }));
+    return {
+      finish: () => resolve({ duration: 1 } as AudioBuffer),
+      fail: () => reject(new Error("stale decode failure")),
+    };
+  }
+
+  it("discards audio stopped while waiting for resume", async () => {
+    const { AudioStreamManager } = await import("./audio-player");
+    const manager = new AudioStreamManager();
+    let resume!: () => void;
+    vi.spyOn(manager, "resume").mockImplementationOnce(() => new Promise<void>(resolve => {
+      resume = resolve;
+    }));
+    const pending = manager.queueAudio(wavChunk);
+    manager.stop();
+    resume();
+    await pending;
+    expect(env.decodeAudioDataMock).not.toHaveBeenCalled();
+    expect(env.sources).toHaveLength(0);
+    expect(manager.isPlaying).toBe(false);
+  });
+
+  it.each(["stop", "clearQueue"] as const)("does not restart pending WAV decoding after %s", async (action) => {
+    const { AudioStreamManager } = await import("./audio-player");
+    const manager = new AudioStreamManager();
+    const decode = deferDecode();
+    const pending = manager.queueAudio(wavChunk);
+    await Promise.resolve();
+    expect(env.decodeAudioDataMock).toHaveBeenCalledTimes(1);
+    manager[action]();
+    decode.finish();
+    await pending;
+    expect(env.sources).toHaveLength(0);
+    expect(manager.isPlaying).toBe(false);
+  });
+
+  it.each(["finish", "fail"] as const)("ignores stale decode %s after new playback starts", async (outcome) => {
+    const { AudioStreamManager } = await import("./audio-player");
+    const manager = new AudioStreamManager();
+    const decode = deferDecode();
+    const pending = manager.queueAudio(wavChunk);
+    await Promise.resolve();
+    manager.clearQueue();
+    await manager.queueAudio(wavChunk);
+    decode[outcome]();
+    await pending;
+    expect(manager.isPlaying).toBe(true);
+    expect(env.sources).toHaveLength(1);
+    expect(env.sources[0].stop).not.toHaveBeenCalled();
+    env.sources[0].onended?.call(env.sources[0], new Event("ended"));
+    expect(env.sources).toHaveLength(1);
+    expect(manager.isPlaying).toBe(false);
+  });
+
+  it("ignores the stopped source's delayed ended event during new playback", async () => {
+    const { AudioStreamManager } = await import("./audio-player");
+    const manager = new AudioStreamManager();
+    await manager.queueAudio(wavChunk);
+    const oldSource = env.sources[0];
+    manager.stop();
+    await manager.queueAudio(wavChunk);
+    oldSource.onended?.call(oldSource, new Event("ended"));
+    expect(manager.isPlaying).toBe(true);
+    expect(env.sources[1].stop).not.toHaveBeenCalled();
   });
 
   it("detects WAV container from RIFF/WAVE header", async () => {

--- a/src/lib/audio-player.ts
+++ b/src/lib/audio-player.ts
@@ -56,6 +56,7 @@ export class AudioStreamManager {
     private playStateListeners: ((playing: boolean) => void)[] = [];
     private animationFrameId?: number;
     private analysisActive = false;
+    private playbackGeneration = 0;
 
     constructor() {
         this.audioContext = new AudioContext();
@@ -99,7 +100,9 @@ export class AudioStreamManager {
     }
 
     public async queueAudio(data: Uint8Array | number[]) {
+        const generation = this.playbackGeneration;
         await this.resume();
+        if (generation !== this.playbackGeneration) return;
 
         const chunk = data instanceof Uint8Array ? data : new Uint8Array(data);
         if (chunk.byteLength === 0) {
@@ -111,7 +114,7 @@ export class AudioStreamManager {
         }
 
         if (this.streamMode === "wav") {
-            await this.queueWavChunk(chunk);
+            await this.queueWavChunk(chunk, generation);
             return;
         }
 
@@ -156,6 +159,8 @@ export class AudioStreamManager {
     }
 
     public stop() {
+        // Invalidate pending resume/decode operations before tearing down playback.
+        this.playbackGeneration++;
         this.audioElement.pause();
         if (this.objectUrl) {
             this.audioElement.removeAttribute("src");
@@ -231,13 +236,15 @@ export class AudioStreamManager {
         }, { once: true });
     }
 
-    private async queueWavChunk(chunk: Uint8Array) {
+    private async queueWavChunk(chunk: Uint8Array, generation: number) {
         try {
             const buffer = chunk.buffer.slice(chunk.byteOffset, chunk.byteOffset + chunk.byteLength);
             const decoded = await this.audioContext.decodeAudioData(buffer);
+            if (generation !== this.playbackGeneration) return;
             this.wavQueue.push(decoded);
             this.playNextWav();
         } catch (error) {
+            if (generation !== this.playbackGeneration) return;
             console.error("[Audio] Failed to decode WAV chunk:", error);
             this.stop();
         }
@@ -263,9 +270,8 @@ export class AudioStreamManager {
         this.startAnalysis();
 
         source.onended = () => {
-            if (this.currentSource === source) {
-                this.currentSource = null;
-            }
+            if (this.currentSource !== source) return;
+            this.currentSource = null;
             if (this.wavQueue.length > 0) {
                 this.playNextWav();
                 return;


### PR DESCRIPTION
## Summary / 概述

Stopping audio while a WAV chunk is decoding could restart the old speech once decoding completed. Invalidate pending playback work on stop so cancelled audio stays stopped and cannot interfere with the next utterance.

## Changes / 变更内容

- Track a playback generation across asynchronous resume and WAV decoding; discard stale successes and failures after stop or clearQueue.
- Ignore delayed ended events from a stopped WAV source when another source is active.
- Add six regression cases covering pending resume, stop/clearQueue during decoding, stale decode success/failure during new playback, and delayed ended events.

## Type / 类型

- [x] `fix` — Bug fix / Bug 修复

## Testing / 测试

- [x] `npm test -- src/lib/audio-player.test.ts` — 8 tests passed.
- [x] `npm test` — 70 files, 741 tests passed.
- [x] `npm run build` — TypeScript check and production build passed; Vite emitted import/chunk-size warnings.
- [x] `npm run check:ipc` — 171 invoked commands verified.
- [x] `git diff --check`

Audio lifecycle tests use mocked browser audio APIs. Desktop/manual audio playback and Rust checks were not run; changes are limited to the frontend audio manager and its tests.

## Behavioral impact / 行为影响

Voice interruption or starting a new TTS stream no longer allows an already pending WAV decode to revive cancelled speech or stop the new utterance. No configuration, model, network, or migration changes are required.

## Content and license review / 内容与授权检查

- [x] No secrets, local databases, model files, generated `dist`, or `target*` directories are included.
- No new assets, permissions, or remote calls.

## Screenshots / 截图

Not applicable: audio lifecycle fix with no UI changes.

## Related Issues / 相关 Issue

No linked issue.
