### PR TITLE
Fix microphone activation after voice interruption stops

### DIFF
--- a/src/core/services/voice-interrupt-service.test.ts
+++ b/src/core/services/voice-interrupt-service.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VoiceInterruptService } from "./voice-interrupt-service";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function microphone() {
+  const stop = vi.fn();
+  const stream = { getTracks: () => [{ stop }] } as unknown as MediaStream;
+  return { stream, stop };
+}
+
+describe("VoiceInterruptService microphone lifecycle", () => {
+  let service: VoiceInterruptService;
+  let getUserMedia: ReturnType<typeof vi.fn>;
+  let createContext: ReturnType<typeof vi.fn<() => void>>;
+  let close: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getUserMedia = vi.fn();
+    createContext = vi.fn();
+    close = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    vi.stubGlobal("AudioContext", class {
+      constructor() { createContext(); }
+      createAnalyser() {
+        return {
+          frequencyBinCount: 256,
+          getByteTimeDomainData: (data: Uint8Array) => data.fill(128),
+        };
+      }
+      createMediaStreamSource() { return { connect: vi.fn(), disconnect: vi.fn() }; }
+      close = close;
+    });
+    vi.stubGlobal("requestAnimationFrame", vi.fn(() => 1));
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    service = new VoiceInterruptService();
+  });
+
+  afterEach(() => {
+    service.stop();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("releases a microphone granted after stop without starting detection", async () => {
+    const request = deferred<MediaStream>();
+    const mic = microphone();
+    getUserMedia.mockReturnValueOnce(request.promise);
+    const pending = service.start();
+    service.stop();
+    request.resolve(mic.stream);
+    await pending;
+    expect(service.isActive).toBe(false);
+    expect(mic.stop).toHaveBeenCalledOnce();
+    expect(createContext).not.toHaveBeenCalled();
+    expect(requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  it("does not acquire multiple microphones for concurrent starts", async () => {
+    const request = deferred<MediaStream>();
+    const mic = microphone();
+    getUserMedia.mockReturnValue(request.promise);
+    const first = service.start();
+    const second = service.start();
+    request.resolve(mic.stream);
+    await Promise.all([first, second]);
+    expect(getUserMedia).toHaveBeenCalledOnce();
+    expect(createContext).toHaveBeenCalledOnce();
+    expect(service.isActive).toBe(true);
+    service.stop();
+    expect(mic.stop).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("releases an old grant without replacing the new active microphone", async () => {
+    const oldRequest = deferred<MediaStream>();
+    const oldMic = microphone();
+    const newMic = microphone();
+    getUserMedia.mockReturnValueOnce(oldRequest.promise).mockResolvedValueOnce(newMic.stream);
+    const oldStart = service.start();
+    service.stop();
+    await service.start();
+    oldRequest.resolve(oldMic.stream);
+    await oldStart;
+    expect(oldMic.stop).toHaveBeenCalledOnce();
+    expect(newMic.stop).not.toHaveBeenCalled();
+    expect(createContext).toHaveBeenCalledOnce();
+    expect(service.isActive).toBe(true);
+    service.stop();
+    expect(newMic.stop).toHaveBeenCalledOnce();
+  });
+
+  it.each(["resolve", "reject"] as const)("keeps a newer pending start protected when the old request settles: %s", async (outcome) => {
+    const oldRequest = deferred<MediaStream>();
+    const newRequest = deferred<MediaStream>();
+    const oldMic = microphone();
+    const newMic = microphone();
+    getUserMedia.mockReturnValueOnce(oldRequest.promise).mockReturnValue(newRequest.promise);
+    const oldStart = service.start();
+    service.stop();
+    const newStart = service.start();
+    if (outcome === "resolve") oldRequest.resolve(oldMic.stream);
+    else oldRequest.reject(new Error("Permission denied"));
+    await oldStart;
+    const duplicate = service.start();
+    newRequest.resolve(newMic.stream);
+    await Promise.all([newStart, duplicate]);
+    expect(getUserMedia).toHaveBeenCalledTimes(2);
+    expect(createContext).toHaveBeenCalledOnce();
+    expect(service.isActive).toBe(true);
+  });
+
+  it("allows retry after microphone permission is denied", async () => {
+    const mic = microphone();
+    getUserMedia.mockRejectedValueOnce(new Error("Permission denied")).mockResolvedValueOnce(mic.stream);
+    await service.start();
+    expect(service.isActive).toBe(false);
+    await service.start();
+    expect(service.isActive).toBe(true);
+    expect(getUserMedia).toHaveBeenCalledTimes(2);
+    await service.start();
+    expect(getUserMedia).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/core/services/voice-interrupt-service.ts
+++ b/src/core/services/voice-interrupt-service.ts
@@ -14,6 +14,8 @@ export class VoiceInterruptService {
     private sourceNode: MediaStreamAudioSourceNode | null = null;
     private rafId: number | null = null;
     private active = false;
+    private starting = false;
+    private generation = 0;
 
     // VAD parameters
     private threshold = 0.04;        // RMS threshold for speech detection
@@ -31,10 +33,13 @@ export class VoiceInterruptService {
      * Call this when TTS starts playing.
      */
     async start(): Promise<void> {
-        if (this.active) return;
+        if (this.active || this.starting) return;
+        this.starting = true;
+        const generation = ++this.generation;
 
+        let stream: MediaStream;
         try {
-            this.stream = await navigator.mediaDevices.getUserMedia({
+            stream = await navigator.mediaDevices.getUserMedia({
                 audio: {
                     echoCancellation: true,
                     noiseSuppression: true,
@@ -42,10 +47,20 @@ export class VoiceInterruptService {
                 },
             });
         } catch (err) {
+            if (generation !== this.generation) return;
+            this.starting = false;
             console.warn("[VoiceInterrupt] Microphone access denied:", err);
             return;
         }
 
+        // A stopped request may still obtain permission; release its own stream
+        // without touching a newer start's resources or pending state.
+        if (generation !== this.generation) {
+            stream.getTracks().forEach(t => t.stop());
+            return;
+        }
+        this.starting = false;
+        this.stream = stream;
         this.audioCtx = new AudioContext();
         this.analyser = this.audioCtx.createAnalyser();
         this.analyser.fftSize = 512;
@@ -68,6 +83,8 @@ export class VoiceInterruptService {
      * Call this when TTS finishes or is interrupted.
      */
     stop(): void {
+        this.generation++;
+        this.starting = false;
         this.active = false;
 
         if (this.rafId != null) {


### PR DESCRIPTION
## Summary / 概述

When TTS ended while microphone permission was still pending, VoiceInterruptService.stop() could be undone by the eventual getUserMedia result. The service would resume listening and keep the microphone open after speech had finished.

## Changes / 变更内容

- Invalidate pending microphone requests on stop and release tracks returned by obsolete requests before creating an audio context.
- Guard concurrent starts so a pending permission request cannot open multiple microphone streams.
- Prevent stale permission successes or failures from changing a newer start's state or resources.
- Add six lifecycle tests covering cancellation, concurrent starts, stale results during active/pending replacement starts, and retry after denial. Five fail against the original implementation.

## Type / 类型

- [x] `fix` — Bug fix / Bug 修复

## Testing / 测试

- [x] `npm test -- src/core/services/voice-interrupt-service.test.ts` — 6 passed.
- [x] `npm test` — 71 files, 741 tests passed.
- [x] `npm run build` — TypeScript and production build passed; Vite emitted import/chunk-size warnings.
- [x] `npm run check:ipc` — 171 invoked commands verified.
- [x] `git diff --cached --check`

Tests use mocked microphone and Web Audio APIs. Desktop microphone permission flows and Rust checks were not run; changes are limited to the frontend service and its tests.

## Behavioral impact / 行为影响

Stopping voice interruption while permission is pending keeps the service stopped. A late microphone grant is immediately released, and a subsequent start can proceed independently. No new permissions, configuration, models, network requirements, or migrations.

## Content and license review / 内容与授权检查

- [x] No secrets, local databases, model files, generated dist, or target directories are included.
- No new assets or remote calls.

## Screenshots / 截图

Not applicable: microphone lifecycle change with no UI changes.

## Related Issues / 相关 Issue

No linked issue. This PR is based on upstream main and is independent of PR #20.
