### PR TITLE
docs: align architecture and API references

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://t.me/+U39dgiUspCo2NDNh"><img src="https://img.shields.io/badge/Telegram-Community-26A5E4?logo=telegram&logoColor=white" alt="Telegram community" /></a>
   <img src="https://img.shields.io/badge/Tauri-v2-24C8DB?logo=tauri&logoColor=white" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/React-18%2B-20232A?logo=react&logoColor=61DAFB" alt="React" />
+  <img src="https://img.shields.io/badge/React-19-20232A?logo=react&logoColor=61DAFB" alt="React 19" />
   <img src="https://img.shields.io/badge/Rust-Stable-000000?logo=rust&logoColor=white" alt="Rust" />
   <img src="https://img.shields.io/badge/License-MIT-2EA44F" alt="MIT License" />
 </p>
@@ -37,7 +37,7 @@
 - 导入 SillyTavern 角色卡，用不同人格延续各自的对话与记忆。
 - 连接本地或云端 LLM，并按需开启语音、视觉、MCP、MOD 和 Bot 能力。
 
-> 三个内置角色、主界面角色选择和首次回复引导正在按[角色生态设计](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md)实施，当前发布版请先使用设置中的角色管理与导入功能。
+> 当前版本内置三个角色，并已提供主界面角色选择、首次回复引导，以及设置中的角色管理与导入功能。设计背景见[角色生态设计](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md)。
 
 ##  Kokoro Engine 的独到之处
 
@@ -77,7 +77,7 @@ Kokoro Engine 不是“聊天壳子 + 桌宠皮肤”。它是一个完整的桌
 
 #### 环境要求
 
-- [Node.js](https://nodejs.org/)（v18+）
+- [Node.js](https://nodejs.org/)（v20.19+ 或 v22.12+）
 - [Rust](https://www.rust-lang.org/tools/install)（stable）
 
 #### 安装与运行
@@ -177,7 +177,7 @@ flowchart LR
   end
 
   subgraph EXT["External Services"]
-    EXT_LLM["OpenAI-Compatible / Ollama / llama.cpp"]
+    EXT_LLM["OpenAI-Compatible / Anthropic / Ollama / llama.cpp / Codex Runtime"]
     EXT_TTS["TTS Providers"]
     EXT_MCP["MCP Servers"]
     EXT_BOT["QQ / Telegram / Discord / LINE / Webhook"]

--- a/README_EN.md
+++ b/README_EN.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://t.me/+U39dgiUspCo2NDNh"><img src="https://img.shields.io/badge/Telegram-Community-26A5E4?logo=telegram&logoColor=white" alt="Telegram community" /></a>
   <img src="https://img.shields.io/badge/Tauri-v2-24C8DB?logo=tauri&logoColor=white" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/React-18%2B-20232A?logo=react&logoColor=61DAFB" alt="React" />
+  <img src="https://img.shields.io/badge/React-19-20232A?logo=react&logoColor=61DAFB" alt="React 19" />
   <img src="https://img.shields.io/badge/Rust-Stable-000000?logo=rust&logoColor=white" alt="Rust" />
   <img src="https://img.shields.io/badge/License-MIT-2EA44F" alt="MIT License" />
 </p>
@@ -36,7 +36,7 @@
 - Import SillyTavern character cards and keep separate conversations and memories.
 - Connect a local or cloud LLM, then opt into voice, vision, MCP, MOD, and bot features.
 
-> Three built-in characters, a main-screen selector, and first-reply onboarding are being implemented from the [character ecosystem design](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md). The current release uses character management and import in Settings.
+> The current version includes three built-in characters, a main-screen selector, first-reply onboarding, and character management/import in Settings. See the [character ecosystem design](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md) for the rationale.
 
 ## What makes Kokoro Engine stand out
 
@@ -76,7 +76,7 @@ Go to the [Releases page](https://github.com/chyinan/Kokoro-Engine/releases), do
 
 #### Requirements
 
-- [Node.js](https://nodejs.org/) (v18+)
+- [Node.js](https://nodejs.org/) (v20.19+ or v22.12+)
 - [Rust](https://www.rust-lang.org/tools/install) (stable)
 
 #### Install and run
@@ -176,7 +176,7 @@ flowchart LR
   end
 
   subgraph EXT["External Services"]
-    EXT_LLM["OpenAI-Compatible / Ollama / llama.cpp"]
+    EXT_LLM["OpenAI-Compatible / Anthropic / Ollama / llama.cpp / Codex Runtime"]
     EXT_TTS["TTS Providers"]
     EXT_MCP["MCP Servers"]
     EXT_BOT["QQ / Telegram / Discord / LINE / Webhook"]

--- a/README_JA.md
+++ b/README_JA.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://t.me/+U39dgiUspCo2NDNh"><img src="https://img.shields.io/badge/Telegram-Community-26A5E4?logo=telegram&logoColor=white" alt="Telegram community" /></a>
   <img src="https://img.shields.io/badge/Tauri-v2-24C8DB?logo=tauri&logoColor=white" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/React-18%2B-20232A?logo=react&logoColor=61DAFB" alt="React" />
+  <img src="https://img.shields.io/badge/React-19-20232A?logo=react&logoColor=61DAFB" alt="React 19" />
   <img src="https://img.shields.io/badge/Rust-Stable-000000?logo=rust&logoColor=white" alt="Rust" />
   <img src="https://img.shields.io/badge/License-MIT-2EA44F" alt="MIT License" />
 </p>
@@ -36,7 +36,7 @@
 - SillyTavern キャラクターカードを取り込み、会話と記憶を分離して保持する。
 - ローカルまたはクラウド LLM を接続し、音声、ビジョン、MCP、MOD、Bot を必要に応じて有効にする。
 
-> 3 体の内蔵キャラクター、メイン画面のセレクター、初回返信オンボーディングは[キャラクターエコシステム設計](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md)に沿って実装中です。現行リリースでは設定画面のキャラクター管理とインポートを使用してください。
+> 現行バージョンには 3 体の内蔵キャラクター、メイン画面のセレクター、初回返信オンボーディング、設定画面のキャラクター管理とインポートが含まれます。背景は[キャラクターエコシステム設計](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md)を参照してください。
 
 ## Kokoro Engine の独自性
 
@@ -76,7 +76,7 @@ Kokoro Engine は「チャット UI + デスクトップペットの見た目」
 
 #### 必要環境
 
-- [Node.js](https://nodejs.org/)（v18+）
+- [Node.js](https://nodejs.org/)（v20.19+ または v22.12+）
 - [Rust](https://www.rust-lang.org/tools/install)（stable）
 
 #### インストールと起動
@@ -176,7 +176,7 @@ flowchart LR
   end
 
   subgraph EXT["External Services"]
-    EXT_LLM["OpenAI-Compatible / Ollama / llama.cpp"]
+    EXT_LLM["OpenAI-Compatible / Anthropic / Ollama / llama.cpp / Codex Runtime"]
     EXT_TTS["TTS Providers"]
     EXT_MCP["MCP Servers"]
     EXT_BOT["QQ / Telegram / Discord / LINE / Webhook"]

--- a/README_KO.md
+++ b/README_KO.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://t.me/+U39dgiUspCo2NDNh"><img src="https://img.shields.io/badge/Telegram-Community-26A5E4?logo=telegram&logoColor=white" alt="Telegram community" /></a>
   <img src="https://img.shields.io/badge/Tauri-v2-24C8DB?logo=tauri&logoColor=white" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/React-18%2B-20232A?logo=react&logoColor=61DAFB" alt="React" />
+  <img src="https://img.shields.io/badge/React-19-20232A?logo=react&logoColor=61DAFB" alt="React 19" />
   <img src="https://img.shields.io/badge/Rust-Stable-000000?logo=rust&logoColor=white" alt="Rust" />
   <img src="https://img.shields.io/badge/License-MIT-2EA44F" alt="MIT License" />
 </p>
@@ -36,7 +36,7 @@
 - SillyTavern 캐릭터 카드를 가져오고 대화와 기억을 캐릭터별로 분리합니다.
 - 로컬 또는 클라우드 LLM을 연결한 뒤 음성, 비전, MCP, MOD, Bot 기능을 필요할 때만 켭니다.
 
-> 내장 캐릭터 3종, 메인 화면 선택기, 첫 응답 온보딩은 [캐릭터 생태계 설계](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md)에 따라 구현 중입니다. 현재 릴리스에서는 설정의 캐릭터 관리와 가져오기를 사용하세요.
+> 현재 버전에는 내장 캐릭터 3종, 메인 화면 선택기, 첫 응답 온보딩, 설정의 캐릭터 관리와 가져오기가 포함됩니다. 배경은 [캐릭터 생태계 설계](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md)를 참고하세요.
 
 ## Kokoro Engine의 차별점
 
@@ -76,7 +76,7 @@ Kokoro Engine은 단순한 채팅 껍데기 + 데스크톱 펫 스킨이 아닙�
 
 #### 요구 사항
 
-- [Node.js](https://nodejs.org/) (v18+)
+- [Node.js](https://nodejs.org/) (v20.19+ 또는 v22.12+)
 - [Rust](https://www.rust-lang.org/tools/install) (stable)
 
 #### 설치 및 실행
@@ -176,7 +176,7 @@ flowchart LR
   end
 
   subgraph EXT["External Services"]
-    EXT_LLM["OpenAI-Compatible / Ollama / llama.cpp"]
+    EXT_LLM["OpenAI-Compatible / Anthropic / Ollama / llama.cpp / Codex Runtime"]
     EXT_TTS["TTS Providers"]
     EXT_MCP["MCP Servers"]
     EXT_BOT["QQ / Telegram / Discord / LINE / Webhook"]

--- a/README_RU.md
+++ b/README_RU.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://t.me/+U39dgiUspCo2NDNh"><img src="https://img.shields.io/badge/Telegram-Community-26A5E4?logo=telegram&logoColor=white" alt="Telegram community" /></a>
   <img src="https://img.shields.io/badge/Tauri-v2-24C8DB?logo=tauri&logoColor=white" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/React-18%2B-20232A?logo=react&logoColor=61DAFB" alt="React" />
+  <img src="https://img.shields.io/badge/React-19-20232A?logo=react&logoColor=61DAFB" alt="React 19" />
   <img src="https://img.shields.io/badge/Rust-Stable-000000?logo=rust&logoColor=white" alt="Rust" />
   <img src="https://img.shields.io/badge/License-MIT-2EA44F" alt="MIT License" />
 </p>
@@ -36,7 +36,7 @@
 - Импортировать карточки SillyTavern и хранить разговоры и память раздельно для каждого персонажа.
 - Подключить локальную или облачную LLM, а затем по необходимости включать голос, vision, MCP, MOD и Bot.
 
-> Три встроенных персонажа, переключатель на главном экране и онбординг до первого ответа разрабатываются по [плану экосистемы персонажей](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md). В текущем релизе используйте управление персонажами и импорт в Settings.
+> Текущая версия включает трёх встроенных персонажей, переключатель на главном экране, онбординг до первого ответа, а также управление персонажами и импорт в Settings. Обоснование описано в [плане экосистемы персонажей](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md).
 
 ## Уникальность Kokoro Engine
 
@@ -76,7 +76,7 @@ Kokoro Engine — это не просто чат-оболочка с внешн
 
 #### Требования
 
-- [Node.js](https://nodejs.org/) (v18+)
+- [Node.js](https://nodejs.org/) (v20.19+ или v22.12+)
 - [Rust](https://www.rust-lang.org/tools/install) (stable)
 
 #### Установка и запуск
@@ -176,7 +176,7 @@ flowchart LR
   end
 
   subgraph EXT["External Services"]
-    EXT_LLM["OpenAI-Compatible / Ollama / llama.cpp"]
+    EXT_LLM["OpenAI-Compatible / Anthropic / Ollama / llama.cpp / Codex Runtime"]
     EXT_TTS["TTS Providers"]
     EXT_MCP["MCP Servers"]
     EXT_BOT["QQ / Telegram / Discord / LINE / Webhook"]

--- a/README_ZH-TW.md
+++ b/README_ZH-TW.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://t.me/+U39dgiUspCo2NDNh"><img src="https://img.shields.io/badge/Telegram-Community-26A5E4?logo=telegram&logoColor=white" alt="Telegram community" /></a>
   <img src="https://img.shields.io/badge/Tauri-v2-24C8DB?logo=tauri&logoColor=white" alt="Tauri v2" />
-  <img src="https://img.shields.io/badge/React-18%2B-20232A?logo=react&logoColor=61DAFB" alt="React" />
+  <img src="https://img.shields.io/badge/React-19-20232A?logo=react&logoColor=61DAFB" alt="React 19" />
   <img src="https://img.shields.io/badge/Rust-Stable-000000?logo=rust&logoColor=white" alt="Rust" />
   <img src="https://img.shields.io/badge/License-MIT-2EA44F" alt="MIT License" />
 </p>
@@ -35,7 +35,7 @@
 - 匯入 SillyTavern 角色卡，保留彼此獨立的對話與記憶。
 - 連接本機或雲端 LLM，再按需開啟語音、視覺、MCP、MOD 與 Bot 功能。
 
-> 三個內建角色、主畫面角色選擇與首次回覆引導正在依照[角色生態設計](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md)實作；目前發行版請使用設定中的角色管理與匯入功能。
+> 目前版本內建三個角色，並已提供主畫面角色選擇、首次回覆引導，以及設定中的角色管理與匯入功能。設計背景請參閱[角色生態設計](docs/design-plans/2026-07-12-user-activation-character-ecosystem.md)。
 
 ## Kokoro Engine 的獨到之處
 
@@ -75,7 +75,7 @@ Kokoro Engine 不是「聊天外殼 + 桌寵皮膚」。它是一個完整的桌
 
 #### 環境需求
 
-- [Node.js](https://nodejs.org/)（v18+）
+- [Node.js](https://nodejs.org/)（v20.19+ 或 v22.12+）
 - [Rust](https://www.rust-lang.org/tools/install)（stable）
 
 #### 安裝與執行
@@ -175,7 +175,7 @@ flowchart LR
   end
 
   subgraph EXT["External Services"]
-    EXT_LLM["OpenAI-Compatible / Ollama / llama.cpp"]
+    EXT_LLM["OpenAI-Compatible / Anthropic / Ollama / llama.cpp / Codex Runtime"]
     EXT_TTS["TTS Providers"]
     EXT_MCP["MCP Servers"]
     EXT_BOT["QQ / Telegram / Discord / LINE / Webhook"]

--- a/docs/API specification.md
+++ b/docs/API specification.md
@@ -1,10 +1,10 @@
 # Kokoro Engine — API specification
 
-> **Version:** 2.0
-> **Last updated:** 2026-04-09
+> **Version:** 2.1
+> **Last updated:** 2026-09-13
 > **Transport:** Tauri IPC (`invoke`) + Tauri events (`emit` / `listen`)
 > **Source of truth:** `src-tauri/src/lib.rs` for registered commands, `src/lib/kokoro-bridge.ts` for frontend bridge wrappers
-> **Related doc:** [architecture.md](file:///d:/Program/Kokoro%20Engine/docs/architecture.md)
+> **Related doc:** [architecture.md](architecture.md)
 
 ---
 
@@ -31,10 +31,33 @@ It covers:
 
 - commands registered in `src-tauri/src/lib.rs`
 - bridge wrappers exported from `src/lib/kokoro-bridge.ts`
-- events emitted by the backend and consumed by the frontend
+- public backend/bridge events and selected cross-window frontend events
 - custom URI schemes used by MODs and Live2D
 
 It does not try to explain internal architecture. Use `architecture.md` for that.
+
+### 2.1 command coverage supplement
+
+The following commands were added after the original 2.0 inventory. Their serialized request and response shapes are defined by Rust command signatures and, where a wrapper exists, `src/lib/kokoro-bridge.ts`. They remain subject to the calling and error conventions in this document.
+
+| Area | Commands |
+|---|---|
+| System | `check_latest_release` |
+| Chat and profile | `is_chat_busy`, `get_user_profile_settings`, `set_user_persona` |
+| Character activation | `prepare_character_activation`, `commit_character_activation`, `get_committed_character_runtime` |
+| Character catalog | `list_character_templates`, `instantiate_character_template`, `duplicate_character`, `restore_character_defaults`, `reconcile_character_template`, `apply_character_template_reconciliation`, `create_character_with_avatar`, `update_character_with_avatar` |
+| Character registry | `list_registry_entries`, `install_character_from_registry`, `install_character_from_url`, `remove_character_package` |
+| Conversations | `edit_conversation_message` |
+| Memory operations | `run_dream_now`, `get_dreaming_summary`, `list_dream_jobs`, `list_dream_proposals`, `approve_dream_proposal`, `reject_dream_proposal` |
+| Memory embedding and observability | `get_memory_embedding_model_status`, `download_memory_embedding_model`, `set_memory_upgrade_config`, `get_memory_upgrade_config`, `get_memory_observability_summary`, `get_latest_memory_write_event`, `get_latest_memory_retrieval_log`, `get_latest_memory_retrieval_eval_summary` |
+| LLM | `test_llm_connection`, `list_anthropic_models`, `get_llama_cpp_status` |
+| Vision | `list_vision_screens`, `set_vision_text_input_focused` |
+| Native audio stream | `process_audio_chunk`, `complete_audio_stream`, `discard_audio_stream`, `snapshot_audio_stream`, `prune_audio_buffer` |
+| MOD lifecycle and registry | `update_mod`, `remove_mod`, `install_mod_from_registry`, `install_mod_from_url` |
+| Unified Bot layer | `get_bot_config`, `save_bot_config`, `respond_qq_authorization`, `start_bot_platform`, `stop_bot_platform`, `get_bot_status` |
+| Pet window | `toggle_pet_window` |
+
+This supplement makes the document inventory complete for the 171 unique frontend-invoked command names registered as of 2026-09-13. `npm run check:ipc` is the required automated consistency check; code remains authoritative if this narrative reference falls behind.
 
 ---
 
@@ -133,6 +156,17 @@ interface ChatRequest {
   images?: string[];
   character_id?: string;
   hidden?: boolean;
+  client_request_id?: string;
+  regenerate?: boolean;
+  conversation_id?: string | null;
+}
+
+interface StreamChatResponse {
+  conversation_id: string;
+  user_message_id?: number | null;
+  assistant_message_id?: number | null;
+  client_request_id?: string | null;
+  status?: "completed" | "cancelled" | string | null;
 }
 ```
 
@@ -205,9 +239,14 @@ interface TtsSystemConfig {
 
 ```ts
 interface VisionConfig {
-  enabled: boolean;
-  interval_secs: number;
+  vlm_enabled: boolean;
+  auto_vision_enabled: boolean;
+  vision_context_history_mode: "latest" | "full";
+  capture_interval_secs: number;
   change_threshold: number;
+  display_id?: string | null;
+  vlm_region?: { x: number; y: number; width: number; height: number } | null;
+  proactive_vision_enabled: boolean;
   vlm_provider: string;
   vlm_base_url: string | null;
   vlm_model: string;
@@ -387,6 +426,13 @@ interface MemoryRecord {
   created_at: number;
   importance: number;
   tier: string;
+  memory_type: string;
+  entity_key: string | null;
+  status: string;
+  confidence: number;
+  first_seen_at: number;
+  last_seen_at: number;
+  evidence_count: number;
 }
 ```
 
@@ -608,6 +654,17 @@ interface CharacterRecord {
   source_format: string;
   created_at: number;
   updated_at: number;
+  template_id?: string | null;
+  template_version?: string | null;
+  template_snapshot_json?: string | null;
+  description?: string;
+  avatar_path?: string | null;
+  greeting?: string;
+  greeting_consumed_at?: number | null;
+  greeting_message_id?: number | null;
+  example_dialogue?: string;
+  runtime_profile_json?: string;
+  user_modified_at?: number | null;
 }
 ```
 
@@ -666,8 +723,8 @@ The tables below list the current IPC commands. The `Bridge` column shows whethe
 | `get_jailbreak_prompt` | `getJailbreakPrompt` | none | `string` | Returns the current jailbreak prompt. |
 | `set_proactive_enabled` | `setProactiveEnabled` | `enabled: boolean` | `void` | Enables or disables proactive messages. |
 | `get_proactive_enabled` | `getProactiveEnabled` | none | `boolean` | Returns proactive toggle state. |
-| `set_memory_enabled` | none | `enabled: boolean` | `void` | Enables or disables memory persistence. |
-| `get_memory_enabled` | none | none | `boolean` | Returns memory toggle state. |
+| `set_memory_enabled` | `setMemoryEnabled` | `enabled: boolean` | `void` | Enables or disables memory persistence. |
+| `get_memory_enabled` | `getMemoryEnabled` | none | `boolean` | Returns memory toggle state. |
 | `clear_history` | `clearHistory` | none | `void` | Clears conversation history. |
 | `delete_last_messages` | `deleteLastMessages` | `count: number`, `expectedConversationId?: string \| null` | `void` | Deletes the last visible messages. Skipped (no-op) when `expectedConversationId` does not match the backend's current conversation, preventing stale deletes after a conversation switch. |
 | `get_context_settings` | `getContextSettings` | none | `ContextSettings` | Returns chat context strategy settings. |
@@ -688,7 +745,7 @@ The tables below list the current IPC commands. The `Bridge` column shows whethe
 
 | Command | Bridge | Request | Response | Notes |
 |---|---|---|---|---|
-| `stream_chat` | `streamChat` | `request: ChatRequest` | `void` | Streaming chat entry point. Emits turn events. |
+| `stream_chat` | `streamChat` | `request: ChatRequest` | `StreamChatResponse` | Streaming chat entry point. Emits turn events and returns persisted message identifiers/status. |
 | `cancel_chat_turn` | `cancelChatTurn` | `turnId: string`, `reason?: string` | `void` | Cancels an in-flight turn. |
 | `approve_tool_approval` | `approveToolApproval` | `approvalRequestId: string` | `void` | Approves a pending tool execution. |
 | `reject_tool_approval` | `rejectToolApproval` | `approvalRequestId: string`, `reason?: string` | `void` | Rejects a pending tool execution. |
@@ -919,6 +976,16 @@ These commands exist in `src-tauri/src/lib.rs`, but `src/lib/kokoro-bridge.ts` d
 | `show_bubble_window` | `pet` | Shows the speech bubble window. |
 | `update_bubble_text` | `pet` | Updates the bubble text. |
 | `hide_bubble_window` | `pet` | Hides the speech bubble window. |
+| `toggle_pet_window` | `pet` | Toggles the floating pet window. |
+| `process_audio_chunk` | `stt::stream` | Appends data to a native audio stream. |
+| `complete_audio_stream` | `stt::stream` | Completes and transcribes a native audio stream. |
+| `discard_audio_stream` | `stt::stream` | Discards a native audio stream. |
+| `snapshot_audio_stream` | `stt::stream` | Returns an audio-stream snapshot. |
+| `prune_audio_buffer` | `stt::stream` | Prunes buffered native audio. |
+| `check_latest_release` | `system` | Checks release metadata. |
+| `update_mod` | `mods` | Updates an installed MOD. |
+| `remove_mod` | `mods` | Removes an installed MOD package. |
+| `install_mod_from_url` | `mods` | Installs an untrusted MOD URL after the caller's confirmation flow. |
 
 ---
 
@@ -931,12 +998,16 @@ These commands exist in `src-tauri/src/lib.rs`, but `src/lib/kokoro-bridge.ts` d
 | `chat-typing` | `TypingParams` | `chat.rs` | none |
 | `chat-turn-start` | `{ turn_id: string }` | `chat.rs` | `onChatTurnStart` |
 | `chat-turn-delta` | `{ turn_id: string; delta: string; ... }` | `chat.rs` | `onChatTurnDelta` |
-| `chat-turn-finish` | `{ turn_id: string; status: "completed" \| "error" }` | `chat.rs` | `onChatTurnFinish` |
+| `chat-turn-finish` | `{ turn_id: string; status: "completed" \| "cancelled" \| "error" }` | `chat.rs` | `onChatTurnFinish` |
 | `chat-turn-translation` | `{ turn_id: string; translation: string }` | `chat.rs` | `onChatTurnTranslation` |
 | `chat-turn-tool` | `ToolTraceItem`-style payload | `chat.rs` | `onChatTurnTool` |
 | `chat-cue` | `{ cue: string; source?: string }` | `chat.rs`, `mods/manager.rs` | `onChatCue` |
 | `chat-imagegen` | `{ prompt: string }` | `actions/builtin.rs` | `onChatImageGen` |
 | `chat-error` | `string` | `chat.rs` | `onChatError` |
+| `chat-warning` | `string` | `chat.rs` | `onChatWarning` |
+| `chat-failure` | `FailureEvent \| string` | `chat.rs` | `onChatFailure` |
+| `chat-turn-acknowledged` | `ChatTurnAcknowledgedEvent` | `chat.rs` | `onChatTurnAcknowledged` |
+| `chat-turn-text-complete` | `ChatTurnTextCompleteEvent` | `chat.rs` | `onChatTurnTextComplete` |
 
 ### TTS events
 
@@ -952,8 +1023,9 @@ These commands exist in `src-tauri/src/lib.rs`, but `src/lib/kokoro-bridge.ts` d
 | Event | Payload | Emitted by | Bridge wrapper |
 |---|---|---|---|
 | `vision-status` | `"active" \| "inactive"` | `vision/watcher.rs` | none |
-| `vision-observation` | `string` | `vision/watcher.rs` | `onVisionObservation` |
-| `proactive-trigger` | `{ trigger: string; idle_seconds: number; instruction: string }` | `vision/watcher.rs`, `ai/heartbeat.rs` | none |
+| `vision-observation` | `string \| { summary: string; captured_at?: string; source?: string }` | `vision/watcher.rs` | `onVisionObservation` |
+| `camera-observation` | `string` | frontend camera watcher | `onCameraObservation` |
+| `proactive-trigger` | `{ trigger: string; instruction: string; idle_seconds?: number }` | `vision/watcher.rs`, `ai/heartbeat.rs` | none |
 
 ### STT events
 
@@ -963,6 +1035,8 @@ These commands exist in `src-tauri/src/lib.rs`, but `src/lib/kokoro-bridge.ts` d
 | `stt:mic-volume` | `{ volume: number; rms: number }` | `stt/mic.rs` | none |
 | `stt:mic-auto-stop` | `()` | `stt/mic.rs` | none |
 | `stt:wake-word-detected` | `string` | `stt/wake_word.rs` | none |
+| `stt:wake-word-error` | `string` | `stt/wake_word.rs` | none |
+| `memory:embedding-model-progress` | `MemoryEmbeddingModelDownloadProgress` | `commands/memory.rs` | `onMemoryEmbeddingModelProgress` |
 
 ### Idle and proactive events
 
@@ -975,6 +1049,11 @@ These commands exist in `src-tauri/src/lib.rs`, but `src/lib/kokoro-bridge.ts` d
 | Event | Payload | Emitted by | Bridge wrapper |
 |---|---|---|---|
 | `live2d-profile-updated` | `Live2dModelProfile`-style payload | `commands/live2d.rs` | none |
+| `live2d-model-selection-updated` | `Live2dSelectionEvent` | frontend/runtime | none |
+| `character-runtime-committed` | `CommittedCharacterRuntime` | character activation | none |
+| `pet-config-updated` | `PetConfig` | pet settings/window | none |
+| `qq-authorization-request` / `qq-authorization-expired` | `QQAuthorizationRequest` | `qqbot/runtime.rs` | none |
+| `qq-authorization-approved` | authorization result payload | `commands/bot.rs` | none |
 | `mod:theme-override` | `ModThemeJson` | `mods/manager.rs` | `onModThemeOverride` |
 | `mod:layout-override` | `unknown` | `mods/manager.rs` | `onModLayoutOverride` |
 | `mod:components-register` | `Record<string, string>` | `mods/manager.rs` | `onModComponentsRegister` |
@@ -1101,11 +1180,11 @@ If you want structured handling, use `parseKokoroError` from `kokoro-bridge.ts`.
 
 ### Exported event wrappers
 
-- chat: `onChatError`, `onChatTurnStart`, `onChatTurnDelta`, `onChatTurnFinish`, `onChatTurnTranslation`, `onChatCue`, `onChatTurnTool`
+- chat: `onChatError`, `onChatWarning`, `onChatFailure`, `onChatTurnStart`, `onChatTurnAcknowledged`, `onChatTurnDelta`, `onChatTurnTextComplete`, `onChatTurnFinish`, `onChatTurnTranslation`, `onChatCue`, `onChatTurnTool`
 - mod: `onModThemeOverride`, `onModLayoutOverride`, `onModComponentsRegister`, `onModUiMessage`, `onModUnload`, `onModScriptEvent`
 - imagegen: `onChatImageGen`, `onImageGenDone`, `onImageGenError`
 - vision: `onVisionObservation`, `onCameraObservation`
-- STT: `onSenseVoiceLocalProgress`
+- STT/memory: `onSenseVoiceLocalProgress`, `onMemoryEmbeddingModelProgress`
 - telegram: `onTelegramChatSync`
 
 ### Bridge-only helpers

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,7 +1,7 @@
 # Kokoro Engine — Product Requirements Document
 
-> **Version:** 1.3
-> **Last Updated:** 2026-07-13
+> **Version:** 1.4
+> **Last Updated:** 2026-09-13
 > **Status:** Active Development
 
 ---
@@ -66,24 +66,26 @@ See the [user activation and character ecosystem design](design-plans/2026-07-12
 
 - [x] Live2D model viewer with interaction (gaze, expressions, hit areas, drawable-level hit testing, cue-driven reactions)
 - [x] Chat system (text input / output, streaming, message editing, continue-from)
-- [x] Pluggable LLM API adapter (OpenAI-compatible + Ollama, multi-provider with presets)
-- [x] Pluggable TTS system (GPT-SoVITS, VITS, OpenAI, Azure, ElevenLabs, Browser TTS)
+- [x] Pluggable LLM API adapters (OpenAI-compatible Chat Completions and Responses, Anthropic, Ollama, llama.cpp, and experimental Codex Runtime; multi-provider presets)
+- [x] Pluggable TTS system (GPT-SoVITS, VITS, OmniVoice, OpenAI, Azure, ElevenLabs, Edge TTS, Browser TTS)
 - [x] Context manager (conversation history, prompt assembly, jailbreak prompts with {{char}}/{{user}} placeholders)
 - [x] Character state and cue mapping (persistent state across restarts, semantic cue routing, expression/motion sync)
 
 ### Post-MVP (Completed ✅)
 
-- [x] Vector memory / RAG systems (three-layer memory: core/ephemeral/consolidated)
+- [x] Vector memory / RAG systems (core and ephemeral persistence tiers plus consolidation/dreaming)
 - [x] Embedding models (FastEmbed all-MiniLM-L6-v2, ONNX offline)
 - [x] MOD system (HTML/CSS/JS UI override, QuickJS script sandbox, custom themes)
 - [x] MCP protocol support (stdio + Streamable HTTP, auto tool registration)
 - [x] Vision system (screen capture, VLM analysis, pixel diff detection)
 - [x] Image generation (Stable Diffusion WebUI, DALL-E, Google Gemini)
-- [x] STT (Whisper, faster-whisper, whisper.cpp)
+- [x] STT (OpenAI Whisper, faster-whisper-compatible endpoints, whisper.cpp, SenseVoice cloud/local, native microphone, VAD, and wake word)
 - [x] Autonomous behavior (curiosity, initiative, idle behaviors)
-- [x] Telegram Bot remote interaction (long polling, text/voice/photo, session commands)
+- [x] Remote interaction through QQ, Telegram, Discord, LINE, and an authenticated generic Webhook
 - [x] Multi-provider LLM (unique Provider IDs, separate main/system LLM)
-- [x] i18n (5 languages: zh, en, ja, ko, ru)
+- [x] Character registry and template/instance lifecycle with source-bound trust and non-destructive package removal
+- [x] Desktop pet and synchronized speech-bubble windows
+- [x] i18n (6 locales: zh, zh-TW, en, ja, ko, ru)
 
 ### Explicitly Out of Scope (for now)
 
@@ -101,7 +103,7 @@ See the [user activation and character ecosystem design](design-plans/2026-07-12
 ┌─────────────────────────────────────┐
 │  1. System Persona                  │  ← Character personality card
 ├─────────────────────────────────────┤
-│  2. Lorebook / World Context        │  ← Optional world-building data
+│  2. Retrieved Memory Context        │  ← Optional character-scoped recall
 ├─────────────────────────────────────┤
 │  3. Conversation History            │  ← Rolling window
 ├─────────────────────────────────────┤
@@ -111,8 +113,8 @@ See the [user activation and character ecosystem design](design-plans/2026-07-12
 
 ### Optimizations
 
-- **Partial refresh** instead of full prompt repetition
-- **Token-efficient** context management
+- **Bounded context assembly** with configurable window or summary strategy
+- **Hybrid memory retrieval** with a keyword fallback when semantic embeddings are unavailable
 
 ---
 
@@ -168,14 +170,14 @@ graph LR
     C -->|Branching narrative| C1[Event scripting]
     D -->|Companion| D1[iOS / Android]
     E -->|Community| E1[Mod marketplace]
-    F -->|Telegram Bot| F1[Text/Voice/Photo ✅]
+    F -->|Bot bridges| F1[QQ/Telegram/Discord/LINE/Webhook ✅]
 ```
 
 | Feature | Status | Description |
 |---|---|---|
-| Advanced Memory | ✅ Done | Three-layer memory (core/ephemeral/consolidated), hybrid search (semantic + BM25 RRF), LLM-driven consolidation |
+| Advanced Memory | ✅ Done | Character-scoped tiers, semantic + BM25/RRF retrieval, non-blocking embedding fallback, observability, and proposal-based dreaming |
 | MOD Ecosystem | ✅ Done | HTML/CSS/JS UI override, QuickJS sandbox, custom themes, Genshin demo MOD |
-| Remote Access | ✅ Done | Telegram Bot with text/voice/photo, session commands, Chat ID whitelist |
+| Remote Access | ✅ Done | QQ, Telegram, Discord, LINE, and authenticated Webhook bridges with character-scoped conversations and bounded media contracts |
 | Story / Narrative Engine | 🔮 Planned | Branching storylines with event scripting |
 | Mobile Companion App | 🔮 Planned | iOS and Android native clients |
-| Character Marketplace | 🔮 Planned | Sharing characters, themes, and plugins |
+| Character Marketplace | 🚧 In progress | Trusted official registry plus confirmed community/custom-source installation; broader workshop UX remains planned |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,792 +1,225 @@
 # Kokoro Engine — Architecture
 
-> **Version:** 2.2
-> **Last Updated:** 2026-04-09
-> **Companion Document:** [PRD.md](PRD.md) · [API Specification](API%20specification.md) · [MOD System Design](MOD_system_design.md)
+> **Version:** 3.0
+> **Last Updated:** 2026-09-13
+> **Companion Documents:** [PRD](PRD.md) · [API Specification](API%20specification.md) · [MOD System Design](MOD_system_design.md) · [Storage Guide](developer-storage-guide.md)
+> **Code sources of truth:** `src-tauri/src/lib.rs` for registered IPC commands and managed services; `src/lib/kokoro-bridge.ts` for frontend bridge types and wrappers.
 
 ---
 
-## 1. High-Level Overview
+## 1. System overview
 
-Kokoro Engine is a **Tauri v2 desktop application** with a dual-layer architecture: a React + TypeScript frontend and a Rust backend, communicating over a typed IPC bridge. It integrates Live2D rendering, LLM conversation, TTS/STT, Vision, Image Generation, MCP protocol, and a MOD system.
+Kokoro Engine 0.4.0 is a local-first Tauri v2 desktop character runtime. React 19 and TypeScript implement the user interface; Rust owns orchestration, persistence, provider integrations, resource safety, and long-running services.
 
+```mermaid
+flowchart LR
+  subgraph Windows["Tauri windows"]
+    Main["Main React UI"]
+    Pet["Desktop pet"]
+    Bubble["Speech bubble"]
+  end
+  Bridge["Typed IPC bridge<br/>commands + events"]
+  subgraph Runtime["Rust runtime"]
+    Commands["IPC command adapters"]
+    AI["Chat and AI orchestration"]
+    Character["Character activation owner"]
+    Media["LLM / TTS / STT / Vision / ImageGen"]
+    Tools["Actions / MCP / MOD runtime"]
+    Bots["QQ / Telegram / Discord / LINE / Webhook"]
+  end
+  subgraph Data["Local data"]
+    SQLite[("SQLite")]
+    Config["Provider and runtime config"]
+    Packages["Character, MOD, and model resources"]
+  end
+  Main <--> Bridge
+  Pet <--> Bridge
+  Bubble <--> Bridge
+  Bridge <--> Commands
+  Commands --> AI
+  Commands --> Character
+  AI --> Media
+  AI --> Tools
+  Bots --> AI
+  Character <--> SQLite
+  AI <--> SQLite
+  Runtime <--> Config
+  Character <--> Packages
 ```
-┌──────────────────────────────────────────────────────────────────────┐
-│                           Tauri Window                               │
-│  ┌────────────────────────────────────────────────────────────────┐  │
-│  │                Frontend  (React + TypeScript)                  │  │
-│  │                                                                │  │
-│  │  ┌─────────┐ ┌────────┐ ┌──────┐ ┌───────┐ ┌──────────────┐  │  │
-│  │  │ Live2D  │ │  Chat  │ │ Mods │ │ Theme │ │   Settings   │  │  │
-│  │  │ Viewer  │ │ Panel  │ │ List │ │Engine │ │    Panel     │  │  │
-│  │  └────┬────┘ └───┬────┘ └──┬───┘ └───────┘ └──────┬───────┘  │  │
-│  │       │          │         │                       │          │  │
-│  │  ─────┴──────────┴─────────┴───────────────────────┴────────  │  │
-│  │                  kokoro-bridge.ts  (Typed IPC)                 │  │
-│  └──────────────────────────┬────────────────────────────────────┘  │
-│                              │  Tauri invoke / events                │
-│  ┌──────────────────────────┴────────────────────────────────────┐  │
-│  │                  Backend  (Rust / Tauri v2)                    │  │
-│  │                                                                │  │
-│  │  ┌────────┐ ┌─────┐ ┌─────┐ ┌─────┐ ┌───────┐ ┌──────────┐  │  │
-│  │  │   AI   │ │ LLM │ │ TTS │ │ STT │ │Vision │ │ ImageGen │  │  │
-│  │  │Orchstr.│ │Adapt│ │ Svc │ │ Svc │ │Watcher│ │   Svc    │  │  │
-│  │  └────────┘ └─────┘ └─────┘ └─────┘ └───────┘ └──────────┘  │  │
-│  │  ┌────────┐ ┌─────┐ ┌─────────┐ ┌──────────┐ ┌───────────┐  │  │
-│  │  │Actions │ │ MCP │ │  Mods   │ │ Memory   │ │  SQLite   │  │  │
-│  │  │Registry│ │Client│ │ Manager │ │ Manager  │ │ +FastEmbed│  │  │
-│  │  └────────┘ └─────┘ └─────────┘ └──────────┘ └───────────┘  │  │
-│  └────────────────────────────────────────────────────────────────┘  │
-└──────────────────────────────────────────────────────────────────────┘
-```
+
+Durable core domain state is backend-owned. The frontend renders state, sequences user interactions, and calls the typed bridge; browser storage still persists UI preferences, background assets, onboarding state, and legacy data. The Rust backend is authoritative for conversations, memories, character instances, activation, provider configuration, package installation, and service lifecycles.
 
 ---
 
-## 2. Project Structure
+## 2. Repository structure
 
-### 2.1 Frontend (`src/`)
+These lists identify current responsibility boundaries rather than attempting to enumerate every file.
 
-```
+### Frontend (`src/`)
+
+```text
 src/
-├── App.tsx                        # Root — MOD system orchestration + layout
-├── main.tsx                       # React entry point
-├── index.css                      # Global styles
-│
-├── core/                          # Service initialization & singletons
-│   ├── init.tsx                   # Component registration bootstrap
-│   ├── services.ts                # Service exports
-│   ├── services/
-│   │   ├── interaction-service.ts # User interaction handling
-│   │   ├── mod-service.ts         # MOD lifecycle management
-│   │   ├── tts-service.ts         # TTS service wrapper
-│   │   └── voice-interrupt-service.ts
-│   └── types/
-│       └── mod.ts                 # Shared type definitions
-│
-├── features/live2d/               # Live2D rendering (PixiJS 6 + Cubism SDK)
-│   ├── Live2DViewer.tsx           # Main Live2D component
-│   ├── Live2DController.ts        # Model control & animation
-│   ├── LipSyncProcessor.ts       # Mouth sync with audio
-│   ├── DrawableHitTest.ts        # Drawable-level hit testing for body regions
-│   └── AudioDebug.tsx             # Audio debugging UI
-│
+├── main.tsx                    React entry point
+├── App.tsx                     Application composition and cross-feature orchestration
+├── core/
+│   ├── services/               Interaction, MOD, TTS, and interruption services
+│   ├── mod-actions/            Host-side MOD action dispatch
+│   └── types/                  Shared frontend contracts
+├── features/
+│   ├── camera/                 Camera watcher lifecycle
+│   ├── characters/             Character catalog and activation UI
+│   ├── live2d/                 PixiJS/Cubism rendering, cues, hit testing, lip sync
+│   ├── onboarding/             First-run experience
+│   └── pet/                    Desktop-pet chat and presentation
+├── lib/
+│   ├── kokoro-bridge.ts        Typed Tauri command/event boundary
+│   ├── db.ts                   Legacy/browser-local IndexedDB helpers
+│   ├── audio-player.ts         Ordered playback and cancellation
+│   └── character-card-parser.ts Character-card import
 ├── ui/
-│   ├── layout/                    # Declarative layout engine (JSON-driven)
-│   │   ├── LayoutRenderer.tsx     # JSON config → React component tree
-│   │   └── types.ts               # LayoutNode, LayoutConfig, ThemeConfig
-│   ├── registry/                  # Component registration (singleton)
-│   │   └── ComponentRegistry.ts   # Core/MOD component registry
-│   ├── theme/                     # Theme system (CSS variables)
-│   │   ├── ThemeContext.tsx        # Theme provider & context
-│   │   └── default.ts             # Default theme config
-│   ├── mods/                      # MOD system integration
-│   │   ├── ModMessageBus.ts       # iframe ↔ host message routing
-│   │   ├── IframeSandbox.tsx      # iframe sandbox wrapper
-│   │   └── ModList.tsx            # MOD list UI
-│   ├── hooks/                     # React hooks
-│   │   ├── useBackgroundSlideshow.ts
-│   │   ├── useTypingReveal.ts
-│   │   └── useVoiceInput.ts
-│   ├── widgets/                   # UI components
-│   │   ├── ChatPanel.tsx          # Chat interface (streaming + tool calls)
-│   │   ├── ChatMessage.tsx        # Chat message bubble (edit, continue-from, regenerate)
-│   │   ├── SettingsPanel.tsx      # Settings modal (persona/model/TTS/STT/vision/MCP/Telegram/pet/backup etc.)
-│   │   ├── HeaderBar.tsx          # Top bar
-│   │   ├── FooterBar.tsx          # Bottom bar (emotion display, real-time sync)
-│   │   ├── BackgroundLayer.tsx    # Background rendering
-│   │   ├── CharacterManager.tsx   # Character CRUD
-│   │   ├── ConversationSidebar.tsx
-│   │   ├── MemoryPanel.tsx        # Memory management UI
-│   │   ├── ImageGenSettings.tsx   # Image generation settings
-│   │   ├── memory/
-│   │   │   ├── MemoryTimeline.tsx # Timeline view
-│   │   │   └── MemoryGraph.tsx    # Keyword graph (CJK-aware)
-│   │   └── settings/              # Settings tabs
-│   │       ├── ApiTab.tsx         # LLM/API config (multi-provider, presets)
-│   │       ├── TtsTab.tsx         # TTS provider setup
-│   │       ├── SttTab.tsx         # Speech-to-text config
-│   │       ├── ModelTab.tsx       # Live2D model selection
-│   │       ├── BackgroundTab.tsx  # Background slideshow
-│   │       ├── VisionTab.tsx      # Vision/screenshot config
-│   │       ├── McpTab.tsx         # MCP server management
-│   │       ├── JailbreakTab.tsx   # Jailbreak prompt config ({{char}}/{{user}} placeholders)
-│   │       └── TelegramTab.tsx    # Telegram Bot config
-│   ├── locales/                   # i18n (5 languages)
-│   │   ├── zh.json                # Simplified Chinese
-│   │   ├── en.json                # English
-│   │   ├── ja.json                # Japanese
-│   │   ├── ko.json                # Korean
-│   │   └── ru.json                # Russian
-│   └── i18n.ts                    # i18next configuration
-│
-├── lib/                           # Utilities & bridges
-│   ├── kokoro-bridge.ts           # Typed IPC wrapper (all Tauri invoke calls)
-│   ├── db.ts                      # IndexedDB for character storage
-│   ├── audio-player.ts            # Audio playback utilities
-│   ├── character-card-parser.ts   # Character card import (JSON/PNG)
-│   └── utils.ts
-│
-└── components/ui/                 # Radix UI primitives
-    └── button.tsx
-
-Settings panel tabs currently include:
-- persona, model, tts, stt, bg, imagegen
-- vision, memory, mcp, mods, telegram
-- api, jailbreak, pet, backup
+│   ├── layout/                 Declarative layout renderer
+│   ├── registry/               Host component registry
+│   ├── mods/                   Sandboxed iframe integration and message bus
+│   ├── theme/                  Theme context and defaults
+│   ├── hooks/                  Voice, wake-word, typing, and background lifecycles
+│   ├── widgets/                Chat, settings, memory, content, and character UI
+│   └── locales/                zh, zh-TW, en, ja, ko, ru
+└── windows/                     Pet and bubble window entry points
 ```
 
-### 2.2 Backend (`src-tauri/src/`)
+`App.tsx` is a composition root, but reusable sequencing and persistence rules belong in feature, service, hook, or reducer modules. Frontend runtime settings may use `localStorage`; durable character and conversation data must go through IPC.
 
-```
+### Backend (`src-tauri/src/`)
+
+```text
 src-tauri/src/
-├── main.rs                        # Tauri entry point
-├── lib.rs                         # Module exports & Tauri setup
-│
-├── commands/                      # IPC command modules (chat/system/config/media/integration)
-│   ├── chat.rs                    # stream_chat + cancellation + tool approval flow
-│   ├── context.rs                 # persona/language/proactive/session controls
-│   ├── character.rs               # Runtime character state & cue control
-│   ├── characters.rs              # Character CRUD
-│   ├── conversation.rs            # Conversation history CRUD
-│   ├── database.rs                # DB initialization & vector store test
-│   ├── tts.rs                     # TTS synthesis/provider config/cache ops
-│   ├── stt.rs                     # Speech-to-text + native mic/wake-word control
-│   ├── llm.rs                     # LLM config & model listing
-│   ├── vision.rs                  # Vision upload/watcher/capture controls
-│   ├── imagegen.rs                # Image generation config + invocation
-│   ├── mcp.rs                     # MCP server lifecycle & tool refresh
-│   ├── mods.rs                    # MOD loading & lifecycle
-│   ├── live2d.rs                  # Live2D model import/export/profile
-│   ├── live2d_protocol.rs         # live2d:// protocol handler
-│   ├── memory.rs                  # Memory CRUD & tiering
-│   ├── actions.rs                 # Action registry & execution
-│   ├── tool_settings.rs           # Tool enablement + max feedback rounds
-│   ├── backup.rs                  # Data export/import
-│   ├── auto_backup.rs             # Scheduled backup config + trigger
-│   ├── pet.rs                     # Desktop pet & bubble window control
-│   ├── system.rs                  # Engine info & system status
-│   ├── telegram.rs                # Telegram Bot config & control
-│   └── mod.rs
-│
-├── ai/                            # AI orchestration & autonomous behavior
-│   ├── context.rs                 # AIOrchestrator — prompt assembly, context mgmt
-│   ├── emotion.rs                 # Emotion state & personality model
-│   ├── emotion_events.rs          # Emotion event types
-│   ├── expression_driver.rs       # Expression → Live2D mapping
-│   ├── memory.rs                  # Memory manager (vector DB + tiering)
-│   ├── memory_extractor.rs        # Auto-extract memories from chat
-│   ├── sentiment.rs               # Sentiment analysis
-│   ├── style_adapter.rs           # Response style adaptation
-│   ├── router.rs                  # Model routing (Fast/Smart/Cheap)
-│   ├── prompts.rs                 # System prompt templates
-│   ├── typing_sim.rs              # Typing animation simulation
-│   ├── curiosity.rs               # Curiosity module (proactive questions)
-│   ├── initiative.rs              # Initiative system (proactive talking)
-│   ├── idle_behaviors.rs          # Idle action triggers
-│   ├── heartbeat.rs               # Periodic background tasks
-│   └── mod.rs
-│
-├── llm/                           # LLM adapters
-│   ├── service.rs                 # LlmService (main interface)
-│   ├── provider.rs                # Provider-neutral LLM contract + OpenAI-compatible adapter
-│   ├── responses.rs               # OpenAI Responses API adapter
-│   ├── codex_runtime.rs           # Experimental Codex app-server runtime bridge
-│   ├── codex_runtime_protocol.rs  # Pure app-server JSONL/request/event conversion
-│   ├── ollama.rs                  # Ollama local inference
-│   ├── context.rs                 # LLM context management
-│   ├── llm_config.rs              # Config persistence
-│   └── mod.rs
-│
-├── tts/                           # Text-to-speech (router + provider adapters)
-│   ├── manager.rs                 # TtsService (main interface)
-│   ├── interface.rs               # TtsProvider trait & types
-│   ├── router.rs                  # Provider routing logic
-│   ├── config.rs                  # Config persistence
-│   ├── cache.rs                   # Audio caching
-│   ├── queue.rs                   # TTS queue management
-│   ├── voice_registry.rs          # Voice profile registry
-│   ├── emotion_tts.rs             # Emotion-aware TTS
-│   ├── openai.rs                  # OpenAI TTS
-│   ├── browser.rs                 # Browser TTS (Web Speech API)
-│   ├── local_gpt_sovits.rs        # GPT-SoVITS local
-│   ├── local_vits.rs              # VITS local
-│   ├── cloud_base.rs              # Cloud provider base
-│   └── mod.rs
-│
-├── stt/                           # Speech-to-text
-│   ├── service.rs                 # SttService
-│   ├── interface.rs               # SttProvider trait
-│   ├── config.rs                  # Config persistence
-│   ├── openai.rs                  # OpenAI Whisper
-│   ├── whisper_cpp.rs             # Whisper.cpp local
-│   ├── stream.rs                  # Audio streaming (chunked)
-│   └── mod.rs
-│
-├── vision/                        # Screen capture & VLM analysis
-│   ├── server.rs                  # Vision HTTP server
-│   ├── capture.rs                 # xcap screenshot
-│   ├── context.rs                 # Vision context
-│   ├── config.rs                  # Config persistence
-│   ├── watcher.rs                 # Screen change watcher (pixel diff)
-│   └── mod.rs
-│
-├── imagegen/                      # Image generation
-│   ├── service.rs                 # ImageGenService
-│   ├── interface.rs               # ImageGenProvider trait
-│   ├── config.rs                  # Config persistence
-│   ├── openai.rs                  # OpenAI DALL-E
-│   ├── stable_diffusion.rs        # Stable Diffusion WebUI
-│   ├── google.rs                  # Google Gemini
-│   └── mod.rs
-│
-├── mcp/                           # Model Context Protocol client
-│   ├── manager.rs                 # McpManager (server lifecycle)
-│   ├── client.rs                  # McpClient (JSON-RPC 2.0)
-│   ├── transport.rs               # stdio + Streamable HTTP transport
-│   ├── bridge.rs                  # MCP tools → ActionRegistry bridge
-│   └── mod.rs
-│
-├── actions/                       # Action registry (LLM tool calling)
-│   ├── registry.rs                # ActionHandler trait, ActionRegistry
-│   ├── builtin.rs                 # Built-in actions (8 handlers)
-│   └── mod.rs
-│
-├── mods/                          # MOD system (QuickJS sandbox)
-│   ├── manager.rs                 # ModManager (lifecycle)
-│   ├── manifest.rs                # mod.json parsing
-│   ├── protocol.rs                # mod:// protocol handler
-│   ├── theme.rs                   # Theme JSON parsing
-│   ├── api.rs                     # QuickJS API (Kokoro.*)
-│   └── mod.rs
-│
-├── telegram/                      # Telegram Bot remote interaction
-│   ├── bot.rs                     # Bot core logic (message handling, voice/image bridge)
-│   ├── config.rs                  # TelegramConfig (token, whitelist, options)
-│   └── mod.rs                     # TelegramService lifecycle (start/stop)
-│
-├── config.rs                      # Global config types
-└── utils/
-    ├── http.rs                    # HTTP utilities
-    └── mod.rs
+├── lib.rs                       Tauri setup, managed services, command registry
+├── commands/                    Thin IPC adapters
+├── ai/                          Prompt assembly, memory, routing, initiative, heartbeat
+├── characters/                  Catalog, instances, merging, serialized activation
+├── chat/                        Stream tag and chat-domain helpers
+├── llm/                         Provider-neutral service and provider adapters
+├── tts/                         Provider registry, routing, queue, cache, synthesis
+├── stt/                         Transcription, streaming, microphone, VAD/wake word
+├── vision/                      Capture, watcher, context, and HTTP ingress
+├── imagegen/                    OpenAI, Stable Diffusion, and Google adapters
+├── actions/                     Built-ins, permissions, execution, and audit
+├── mcp/                         Client, transports, connection manager, action bridge
+├── mods/                        Package manager, QuickJS runtime, theme and URI protocol
+├── registry/                    Content index, trust, download, and installation
+├── qqbot/                       QQ gateway, protocol, configuration, authorization
+├── telegram/                    Telegram long-polling service
+├── hooks/                       Runtime hook dispatch and audit handler
+├── config.rs                    Shared persisted configuration
+└── utils/                       HTTP, download, and logging helpers
 ```
 
-### 2.3 MOD System (`mods/`)
+Database schema changes live in `src-tauri/migrations/`. Tauri capabilities for the main, pet, and bubble windows live in `src-tauri/capabilities/`.
 
-```
-mods/
-├── default/                       # Default Hiyori character
-│   ├── mod.json                   # Manifest
-│   └── theme.json                 # Default theme variables
-│
-└── genshin-theme/                 # Genshin Impact UI theme (demo MOD)
-    ├── mod.json                   # Manifest with component overrides
-    ├── theme.json                 # Genshin color palette & animations
-    ├── components/
-    │   ├── chat.html              # Chat panel override (iframe)
-    │   ├── settings.html          # Settings panel override
-    │   └── style.css
-    └── assets/
-        └── HYWenHei-85W.ttf      # Genshin font
-```
+### Content and integrations
 
-### 2.4 Database (SQLite + FastEmbed)
-
-```
-~/.local/share/com.chyin.kokoro/   # (or OS-appropriate app data dir)
-├── kokoro.db                      # SQLite database
-│   ├── memories                   # content, embedding, importance, tier, character_id
-│   ├── conversations              # chat history
-│   └── characters                 # character metadata
-├── llm_config.json                # LLM provider config (multi-provider, presets)
-├── tts_config.json
-├── stt_config.json
-├── vision_config.json
-├── imagegen_config.json
-├── mcp_servers.json
-├── telegram_config.json           # Telegram Bot config (token, whitelist)
-└── emotion_state.json             # Persisted emotion state across restarts
+```text
+characters/                      kokoro, pico, seren, and authoring template packages
+mods/genshin-theme/              Bundled demonstration MOD
+registry/                        Deterministic registry index and package artifacts
+integrations/astrbot-kokoro/     AstrBot adapter and tests
+scripts/                         IPC, registry, and storage-sentinel tooling
 ```
 
 ---
 
-## 3. Layer Architecture
+## 3. Stable domain boundaries
 
-### 3.1 Frontend Layer
+### Character templates and instances
 
-```mermaid
-graph TD
-    App["App.tsx"] --> TP["ThemeProvider"]
-    TP --> LR["LayoutRenderer"]
-    LR --> CR["ComponentRegistry"]
-    CR --> L2D["Live2DStage"]
-    CR --> CP["ChatPanel"]
-    CR --> SP["SettingsPanel"]
-    CR --> ML["ModList"]
+A template is versioned source content. A character instance is the user's editable copy and owns its conversations, memories, greeting state, and per-character runtime overrides. Removing or updating a source package must not erase user instances or their data.
 
-    L2D --> Pixi["PixiJS + Cubism SDK"]
-    CP --> Bridge["kokoro-bridge.ts"]
-    SP --> Bridge
-    ML --> Bridge
+Character switching is serialized by the activation coordinator. Changes follow a prepare/apply/commit flow so the UI, persisted state, Live2D resources, and backend runtime do not observe partially activated characters. Provider credentials remain app-wide and are never copied into character packages.
 
-    Bridge -->|"invoke()"| Tauri["Tauri IPC"]
-    Bridge -->|"listen()"| Events["Tauri Events"]
+### Chat turns
 
-    subgraph "UI Framework"
-        LR
-        CR
-        TP
-    end
+`stream_chat` starts a turn identified by a turn ID. The backend emits start, delta, cue/tool/translation, and finish events. Cancellation and late events are scoped to the owning turn and conversation. The frontend must not apply results from a stale generation after a conversation or character switch.
+
+### Memory
+
+Memories and conversations are character-scoped in SQLite. Retrieval combines keyword search with optional local embeddings and ranking fusion. Embedding availability is an enhancement, not a prerequisite: failures return a typed unavailable state and fall back to keyword retrieval so ordinary chat remains usable.
+
+Dreaming performs memory consolidation through background jobs and reviewable proposals. Proposal approval validates character ownership, pending status, and source-memory revision snapshots before transactional mutation.
+
+### Providers and media
+
+- LLM: OpenAI-compatible Chat Completions, OpenAI Responses, Anthropic, Ollama, llama.cpp, and experimental Codex Runtime.
+- TTS: Browser, OpenAI, Azure, ElevenLabs, Edge TTS, GPT-SoVITS, VITS, and OmniVoice.
+- STT: OpenAI/faster-whisper-compatible services, whisper.cpp, SenseVoice remote/local, native microphone streaming, VAD, and wake word.
+- Vision: uploaded images, screen capture, change watcher, and bounded authenticated ingress.
+- Image generation: OpenAI, Stable Diffusion WebUI, and Google providers.
+
+Provider selection and credentials are stored in local app configuration. Codex Runtime delegates to `codex app-server` and does not read or persist Codex credentials.
+
+### Tools, MCP, and MODs
+
+Built-in actions and MCP tools share the action registry and permission system. MCP supports stdio, SSE compatibility, and Streamable HTTP transports. Connections use generation ownership so stale readers or pending responses cannot mutate a replacement connection.
+
+MOD scripts run in QuickJS and MOD UI runs in sandboxed iframes. Host actions require manifest-declared, host-approved permissions; unknown high-impact actions fail closed. `mod://` resources are containment checked and MOD unload removes listeners and runtime state.
+
+### Bot bridges
+
+The product exposes QQ, Telegram, Discord, LINE, and an authenticated generic Webhook. Incoming traffic is bounded, authenticated or allowlisted as appropriate, and mapped to character-scoped conversations. Text, image, and audio have explicit contracts; AstrBot audio produced through `Record.convert_to_base64()` is WAV.
+
+---
+
+## 4. Persistence and resource safety
+
+The platform-specific app-data directory contains `kokoro.db`, provider/runtime JSON configuration, installed packages, models, caches, and backups. SQLite is authoritative for character instances, conversations, summaries, memories, and memory-management jobs.
+
+Registry, backup, and package writes use staging followed by promotion. Before promotion, the backend enforces canonical containment, entry and aggregate size limits, and reparse-point/symlink protections. Registry trust is source-bound: only the canonical official endpoint together with the official identity can produce an official label. Custom-registry and direct-URL installs remain community/untrusted; direct URL installs require confirmation, while executable MODs additionally require explicit permission confirmation.
+
+Secrets must not be committed or included in exported configuration. Backup export recursively redacts sensitive configuration, and import validates relationships before applying data.
+
+---
+
+## 5. IPC and protocol boundaries
+
+All supported frontend calls should be represented in `src/lib/kokoro-bridge.ts`. Every invoked command must be registered in the `tauri::generate_handler![]` list in `src-tauri/src/lib.rs`. Run `npm run check:ipc` whenever either side changes.
+
+The application also exposes narrowly scoped custom schemes:
+
+- `live2d://` for validated Live2D resources.
+- `character-instance-resource://` for validated instance-owned resources.
+- `mod://` for installed MOD resources.
+
+Event payloads, commands, and bridge types are documented in the [API specification](API%20specification.md).
+
+---
+
+## 6. Verification
+
+Use checks proportional to the affected boundary:
+
+```bash
+npm test
+npm run build
+npm run check:ipc
+cargo test --manifest-path src-tauri/Cargo.toml
+cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings
+cd integrations/astrbot-kokoro && pytest -q
 ```
 
-| Pattern | Implementation |
+Registry changes additionally require `node scripts/build-content-registry.mjs` and its focused tests. Vision concurrency work should include the `stress` feature suite. User-visible changes should be verified in the Tauri app, including the relevant auxiliary window.
+
+---
+
+## 7. Current implementation summary
+
+| Area | Current state |
 |---|---|
-| **Declarative layout** | JSON config → `LayoutRenderer` → grid/layer/component tree |
-| **Component registry** | `ComponentRegistry` — register-by-name, resolve at render time, MOD override support |
-| **Theming** | `ThemeProvider` context with CSS variable injection, MOD theme override |
-| **Typed IPC** | `kokoro-bridge.ts` wraps every `invoke()` with TypeScript types |
-| **Event streaming** | Turn-scoped chat events (`onChatTurnStart`, `onChatTurnDelta`, `onChatTurnFinish`, `onChatTurnTranslation`, `onChatTurnTool`) plus `onChatCue` / `onChatError` via Tauri events |
-| **i18n** | i18next with 5 languages (zh, en, ja, ko, ru) |
-
-### 3.2 Backend Layer
-
-```mermaid
-graph TD
-    CMD["commands/"] -->|"manage()"| AIO["AIOrchestrator"]
-    CMD --> TTS["TtsService"]
-    CMD --> STT["SttService"]
-    CMD --> VIS["VisionWatcher"]
-    CMD --> IMG["ImageGenService"]
-    CMD --> MCP["McpManager"]
-    CMD --> MM["ModManager"]
-    CMD --> ACT["ActionRegistry"]
-    CMD --> TG["TelegramService"]
-
-    AIO --> CTX["Context Manager"]
-    AIO --> MEM["Memory Manager"]
-    AIO --> EMO["Emotion System"]
-    AIO --> HB["Heartbeat"]
-    AIO --> LLM["LLM Adapter"]
-
-    HB --> INIT["Initiative"]
-    HB --> IDLE["Idle Behaviors"]
-    HB --> CUR["Curiosity"]
-
-    LLM --> OAI["openai.rs"]
-    LLM --> OLL["ollama.rs"]
-
-    TTS --> IF["TtsProvider trait"]
-    IF --> SOVITS["GPT-SoVITS"]
-    IF --> OAITTS["OpenAI TTS"]
-    IF --> BTTS["Browser TTS"]
-
-    MCP --> BRIDGE["MCP Bridge"]
-    BRIDGE --> ACT
-
-    subgraph "AI Pipeline"
-        AIO
-        CTX
-        MEM
-        EMO
-        LLM
-    end
-
-    subgraph "Autonomous Behavior"
-        HB
-        INIT
-        IDLE
-        CUR
-    end
-
-    subgraph "TTS Pipeline"
-        TTS
-        IF
-    end
-
-    subgraph "Tool System"
-        ACT
-        MCP
-        BRIDGE
-    end
-```
-
-| Pattern | Implementation |
-|---|---|
-| **Pluggable LLM** | OpenAI-compatible + Ollama + experimental Codex Runtime adapters; model routing remains provider-specific |
-| **Pluggable TTS** | `TtsProvider` trait + capability router + fallback chain (preferred/default/browser) |
-| **Pluggable ImageGen** | `ImageGenProvider` trait — Stable Diffusion, DALL-E, Gemini |
-| **Tool calling** | `ActionHandler` trait with `needs_feedback()` for feedback loop control |
-| **MCP integration** | MCP tools auto-registered into `ActionRegistry` via `bridge.rs` |
-| **Managed state** | Tauri `app.manage()` — AIOrchestrator, TtsService, McpManager, etc. |
-| **Async-first** | All I/O uses `tokio` async runtime; `Arc<RwLock<T>>` for shared state |
-| **Mod isolation** | QuickJS ES2020 sandbox + iframe sandboxing for UI components |
-
----
-
-## 4. IPC Contract
-
-All frontend ↔ backend communication flows through **`kokoro-bridge.ts`** (frontend) and **`commands/`** (backend).
-
-### Commands (invoke-based)
-
-The command set is defined by `tauri::generate_handler![]` in `src-tauri/src/lib.rs`.
-
-| Domain | Commands | Module |
-|---|---|---|
-| Chat turn | `stream_chat`, `cancel_chat_turn`, `approve_tool_approval`, `reject_tool_approval`, `get_context_settings`, `set_context_settings` | `chat.rs` |
-| Context | `set_persona`, `set_character_name`, `set_active_character_id`, `set_user_name`, `set_response_language`, `set_user_language`, `set_jailbreak_prompt`, `get_jailbreak_prompt`, `set_proactive_enabled`, `get_proactive_enabled`, `set_memory_enabled`, `get_memory_enabled`, `clear_history`, `delete_last_messages`, `end_session` | `context.rs` |
-| System + character | `get_engine_info`, `get_system_status`, `set_window_size`, `get_character_state`, `play_cue`, `send_message` | `system.rs`, `character.rs` |
-| Database | `init_db`, `test_vector_store` | `database.rs` |
-| TTS | `synthesize`, `list_tts_providers`, `list_tts_voices`, `get_tts_provider_status`, `clear_tts_cache`, `get_tts_config`, `save_tts_config`, `list_gpt_sovits_models` | `tts.rs` |
-| STT | `transcribe_audio`, `get_stt_config`, `save_stt_config`, `transcribe_wake_word_audio`, `start_native_mic`, `stop_native_mic`, `start_native_wake_word`, `stop_native_wake_word`, `get_sensevoice_local_status`, `download_sensevoice_local_model` | `stt.rs` |
-| STT streaming buffer | `process_audio_chunk`, `complete_audio_stream`, `discard_audio_stream`, `snapshot_audio_stream`, `prune_audio_buffer` | `stt/stream.rs` |
-| LLM | `get_llm_config`, `save_llm_config`, `get_codex_runtime_status`, `list_codex_runtime_models`, `list_ollama_models` | `llm.rs` |
-| Vision | `upload_vision_image`, `get_vision_config`, `save_vision_config`, `start_vision_watcher`, `stop_vision_watcher`, `capture_screen_now` | `vision.rs` |
-| Image generation | `generate_image`, `get_imagegen_config`, `save_imagegen_config`, `test_sd_connection` | `imagegen.rs` |
-| Memory | `list_memories`, `update_memory`, `delete_memory`, `update_memory_tier` | `memory.rs` |
-| Character CRUD | `list_characters`, `create_character`, `update_character`, `delete_character`, `list_character_ids` | `characters.rs`, `conversation.rs` |
-| Conversation CRUD | `list_conversations`, `load_conversation`, `delete_conversation`, `create_conversation`, `rename_conversation`, `update_conversation_state` | `conversation.rs` |
-| Action / tooling | `list_actions`, `list_builtin_tools`, `execute_action`, `get_tool_settings`, `save_tool_settings` | `actions.rs`, `tool_settings.rs` |
-| MCP | `list_mcp_servers`, `add_mcp_server`, `remove_mcp_server`, `refresh_mcp_tools`, `reconnect_mcp_server`, `toggle_mcp_server` | `mcp.rs` |
-| MOD | `list_mods`, `load_mod`, `install_mod`, `get_mod_theme`, `get_mod_layout`, `dispatch_mod_event`, `unload_mod` | `mods.rs` |
-| Live2D assets | `import_live2d_zip`, `import_live2d_folder`, `export_live2d_model`, `list_live2d_models`, `delete_live2d_model`, `rename_live2d_model`, `get_live2d_model_profile`, `save_live2d_model_profile`, `set_active_live2d_model` | `live2d.rs` |
-| Telegram | `get_telegram_config`, `save_telegram_config`, `start_telegram_bot`, `stop_telegram_bot`, `get_telegram_status` | `telegram.rs` |
-| Backup | `export_data`, `preview_import`, `import_data`, `get_auto_backup_config`, `save_auto_backup_config`, `run_auto_backup_now` | `backup.rs`, `auto_backup.rs` |
-| Pet window | `show_pet_window`, `hide_pet_window`, `set_pet_drag_mode`, `get_pet_config`, `save_pet_config`, `move_pet_window`, `resize_pet_window`, `show_bubble_window`, `update_bubble_text`, `hide_bubble_window` | `pet.rs` |
-
-### Events (runtime)
-
-| Event | Direction | Purpose |
-|---|---|---|
-| `chat-turn-start` / `chat-turn-delta` / `chat-turn-finish` / `chat-turn-translation` | BE → FE | Turn-scoped streaming lifecycle. |
-| `chat-turn-tool` | BE → FE | Tool execution trace, result/error, approval metadata. |
-| `chat-error` | BE → FE | Chat pipeline error surface. |
-| `chat-cue` | BE → FE | Cue playback trigger from chat/tool/MOD paths. |
-| `chat-imagegen`, `imagegen:done`, `imagegen:error` | BE → FE | Image generation request + completion/failure. |
-| `chat-typing` | BE → FE | Typing simulation events. |
-| `vision-observation`, `vision-status`, `camera-observation` | BE → FE | Vision watcher observations and status. |
-| `tts:start`, `tts:audio`, `tts:browser-delegate`, `tts:end` | BE → FE | TTS playback lifecycle and browser delegation. |
-| `stt:sensevoice-local-progress`, `stt:mic-auto-stop`, `stt:wake-word-detected` | BE → FE | STT model download and microphone/wake-word events. |
-| `memory:updated` | BE → FE | Memory panel refresh trigger after write/delete operations. |
-| `mod:theme-override`, `mod:layout-override`, `mod:components-register`, `mod:unload`, `mod:script-event`, `mod:ui-message` | BE ↔ FE | MOD UI/script synchronization channel. |
-| `idle-behavior` | BE → FE | Heartbeat-driven idle behavior signal. |
-| `live2d-profile-updated` | BE → FE | Active model profile changed. |
-| `pet-window-closed`, `bubble-text-update`, `toggle-chat-input` | BE → FE | Pet window/bubble UI state synchronization. |
-
----
-
-## 5. Module Deep Dives
-
-### 5.1 AI Pipeline & Tool Feedback Loop
-
-```
-User message
-    │
-    ▼
-┌──────────────┐     ┌───────────────┐     ┌──────────────┐
-│   Context    │────▶│   Prompt      │────▶│  LLM Adapter │
-│   Manager    │     │   Assembly    │     │(OpenAI/Ollama)│
-└──────────────┘     └───────────────┘     └──────┬───────┘
-                                                   │
-                              ┌─────────────────────┘
-                              ▼
-                     ┌─────────────────┐
-                     │  Tool Feedback  │ (configurable, default 10 rounds)
-                     │     Loop        │
-                     └────────┬────────┘
-                              │
-              ┌───────────────┼───────────────┐
-              ▼               ▼               ▼
-        ┌──────────┐   ┌──────────┐   ┌──────────┐
-        │chat-turn-│   │ Parse    │   │ Execute  │
-        │ delta    │   │[TOOL_CALL│   │ Actions  │
-        │ events   │   │  tags]   │   │          │
-        │(buffered)│   └──────────┘   └────┬─────┘
-                                           │
-                              ┌─────────────┘
-                              ▼
-                     ┌─────────────────┐
-                     │ needs_feedback? │
-                     └────────┬────────┘
-                         yes/ \no
-                        /     \
-                       ▼       ▼
-              [inject result  [break loop]
-               → next round]
-```
-
-**Tool Feedback Loop** (`commands/chat.rs`):
-1. Emit `chat-turn-start` for the assistant turn
-2. LLM streams response → `chat-turn-delta` events (with tag buffering)
-3. Parse `[TOOL_CALL:name|args]` tags from response
-4. If no tool calls → break (final round)
-5. Execute tools via `ActionRegistry`
-6. Check `needs_feedback()` — info-retrieval tools (get_time, search_memory, forget_memory, MCP tools) return `true`; side-effect tools (play_cue, set_background, send_notification, store_memory) return `false`
-7. If any tool needs feedback → inject assistant message + tool results into context → next round
-8. If no tool needs feedback → break
-9. Emit `chat-turn-finish`, plus `chat-turn-translation` / `chat-cue` when applicable
-
-**Stream Buffering**: `[TOOL_CALL:...]` and `[TRANSLATE:...]` tags are held in a buffer during streaming and never sent to the frontend raw.
-
-**Prompt Assembly Notes**:
-- current emotion state is not injected into the main chat prompt
-- active Live2D cue names are injected when a model profile exposes prompt-visible cues
-- cues marked `exclude_from_prompt` stay available at runtime but are hidden from prompt guidance
-
-### 5.2 Action System
-
-```
-ActionRegistry
-├── Built-in Actions (builtin.rs)
-│   ├── get_time            (needs_feedback: true)
-│   ├── search_memory       (needs_feedback: true)
-│   ├── forget_memory       (needs_feedback: true)
-│   ├── store_memory        (needs_feedback: false)
-│   ├── play_cue            (needs_feedback: false)
-│   ├── set_background      (needs_feedback: false)
-│   └── send_notification   (needs_feedback: false)
-│
-└── MCP Tools (bridge.rs)       (needs_feedback: true, always)
-    └── Dynamically registered from connected MCP servers
-```
-
-### 5.3 Memory System
-
-Three-layer architecture:
-
-| Layer | Description |
-|---|---|
-| **Core memories** | Important facts, permanently stored, never decay |
-| **Ephemeral memories** | Temporary observations, naturally decay over time |
-| **Consolidated memories** | LLM-driven clustering of similar fragments |
-
-**Retrieval**: Hybrid semantic + keyword search
-- Embedding cosine similarity (FastEmbed all-MiniLM-L6-v2, ONNX offline)
-- FTS5 BM25 full-text search
-- RRF (Reciprocal Rank Fusion) for rank merging
-
-**Auto-extraction**: `memory_extractor.rs` automatically identifies key facts from conversations and stores them.
-
-### 5.4 Autonomous Behavior System
-
-The **heartbeat** (`ai/heartbeat.rs`) runs periodic background tasks:
-
-| Module | Purpose |
-|---|---|
-| `initiative.rs` | Proactive talking — character initiates conversation when user is idle |
-| `idle_behaviors.rs` | Idle actions — expression changes, ambient animations |
-| `curiosity.rs` | Curiosity — character asks questions about topics of interest |
-
-Triggers are time-based (idle duration) and context-aware (time of day, conversation history).
-
-### 5.5 TTS Pipeline
-
-```
-Text ──▶ TtsService ──▶ TtsRouter::select_provider() ──▶ TtsProvider::synthesize() ──▶ Audio bytes/events
-              │                         │
-              │                         ├─ preferred provider (if available)
-              │                         ├─ capability score ranking
-              │                         ├─ default provider fallback
-              │                         └─ browser fallback
-              │
-              ├─ local_gpt_sovits.rs
-              ├─ local_vits.rs
-              ├─ openai.rs
-              ├─ edge.rs
-              └─ browser.rs
-```
-
-- **`TtsProvider` trait** — provider abstraction for synth and capabilities.
-- **Router-driven selection** — `router.rs` picks providers by preference + capability score.
-- **Emotion-aware adaptation** — `emotion_tts.rs` adjusts runtime voice parameters.
-- **Caching + queue** — `cache.rs` avoids duplicate synthesis; `queue.rs` serializes playback.
-- **Runtime events** — `tts:start`, `tts:audio`, `tts:browser-delegate`, `tts:end`.
-
-### 5.6 MCP Protocol
-
-```
-MCP Server (external process)
-    │ stdio / Streamable HTTP
-    ▼
-McpClient (JSON-RPC 2.0)
-    │
-    ▼
-McpManager (server lifecycle)
-    │
-    ▼
-MCP Bridge → ActionRegistry
-    │
-    ▼
-LLM tool calling via [TOOL_CALL:...] tags
-```
-
-- Supports **stdio** and **Streamable HTTP** transports
-- MCP tools are automatically registered as `ActionHandler` instances
-- All MCP tools default to `needs_feedback: true`
-
-### 5.7 MOD System
-
-```
-mods/example-mod/
-├── mod.json          # Manifest (id, name, version, components, scripts, permissions)
-├── theme.json        # CSS variables, fonts, animations
-├── layout.json       # Optional layout overrides
-├── components/       # HTML files (rendered in iframe sandbox)
-└── scripts/          # QuickJS ES2020 code
-```
-
-- **UI Components**: HTML/CSS/JS in iframe sandbox, communicate via `ModMessageBus` (postMessage)
-- **Scripts**: QuickJS runtime with `Kokoro.*` API (`Kokoro.on()`, `Kokoro.emit()`, `Kokoro.ui.send()`, `Kokoro.character.playCue()`)
-- **Themes**: CSS variable injection, font loading, animation definitions
-- **`mod://` protocol**: Custom URI scheme serving mod assets with path traversal protection
-
-### 5.8 Telegram Bot
-
-```
-Telegram ←→ teloxide (long polling) ←→ TelegramService (background task)
-                                            ↓
-                                  app_handle.try_state::<T>()
-                                            ↓
-                          ┌─────────────────┼─────────────────┐
-                          ↓                 ↓                 ↓
-                    AIOrchestrator    TtsService        ImageGenService
-                    + LlmService      (voice reply)     (image gen)
-                    (text chat)       SttService
-                                      (voice transcribe)
-```
-
-- **Long polling** — No public IP required; uses `teloxide` Rust framework
-- **Access control** — Chat ID whitelist; unauthorized messages are silently ignored
-- **Session commands** — `/new` (new conversation), `/continue` (resume desktop session), `/status`
-- **Message types** — Text, voice (STT → LLM → TTS), photo (with Vision)
-- **Desktop sync** — Telegram messages are synced to the desktop chat UI in real-time
-
----
-
-## 6. Data Flow Diagrams
-
-### 6.1 Chat Message Flow (with Tool Feedback)
-
-```mermaid
-sequenceDiagram
-    participant U as User
-    participant CP as ChatPanel
-    participant BR as kokoro-bridge
-    participant CMD as commands/chat
-    participant AI as AIOrchestrator
-    participant LLM as LLM API
-    participant ACT as ActionRegistry
-
-    U->>CP: Type message
-    CP->>BR: streamChat(request)
-    BR->>CMD: invoke("stream_chat")
-    CMD->>AI: compose_prompt()
-    CMD-->>BR: emit("chat-turn-start", turn_id)
-
-    loop Tool Feedback Loop (configurable, default 10 rounds)
-        AI->>LLM: POST /chat/completions (stream)
-        loop SSE chunks
-            LLM-->>CMD: data: {"delta": "..."}
-            CMD-->>BR: emit("chat-turn-delta", {turn_id, delta})
-            BR-->>CP: onChatTurnDelta callback
-        end
-        CMD->>CMD: parse [TOOL_CALL:...] tags
-        alt Has tool calls with needs_feedback
-            CMD->>ACT: execute tools
-            ACT-->>CMD: tool results
-            CMD-->>BR: emit("chat-turn-tool")
-            CMD->>CMD: inject results → next round
-        else No tool calls or no feedback needed
-            CMD->>CMD: break loop
-        end
-    end
-
-    CMD-->>BR: emit("chat-turn-translation", combined)
-    CMD-->>BR: emit("chat-turn-finish", status)
-    BR-->>CP: onChatTurnFinish callback
-```
-
-### 6.2 TTS Flow
-
-```mermaid
-sequenceDiagram
-    participant FE as Frontend
-    participant BR as kokoro-bridge
-    participant CMD as commands/tts
-    participant SVC as TtsService
-    participant P as TtsProvider
-    participant AP as AudioPlayer
-
-    FE->>BR: synthesize(text, config)
-    BR->>CMD: invoke("synthesize")
-    CMD->>SVC: synthesize(text, params)
-    SVC->>P: provider.synthesize(text, params)
-    P-->>SVC: Vec<u8> (audio)
-    SVC-->>CMD: audio bytes
-    CMD-->>BR: Uint8Array
-    BR-->>FE: audio data
-    FE->>AP: play(audioData)
-```
-
----
-
-## 7. Key Design Decisions
-
-| Decision | Rationale |
-|---|---|
-| **Tauri v2 over Electron** | Smaller binary, native Rust backend, lower memory footprint |
-| **Typed IPC bridge** | Single source of truth for FE↔BE contract; catches mismatches at compile time |
-| **Trait-based plugins** | `TtsProvider`, `LlmProvider`, `ImageGenProvider`, `ActionHandler` traits enable swapping implementations |
-| **Tool feedback loop** | LLM sees tool results and can incorporate them naturally, enabling info-retrieval tools |
-| **`needs_feedback` trait method** | Prevents infinite loops from side-effect tools while ensuring info tools get results back |
-| **Stream tag buffering** | `[TOOL_CALL:...]` and `[TRANSLATE:...]` tags never leak to frontend display |
-| **Declarative layout** | Enables MOD-driven UI composition; layouts loaded from JSON config |
-| **Component registry** | Decouples layout from implementation; MODs can inject/override components |
-| **Offline-first** | AI orchestrator failure is non-fatal; app launches without network |
-| **QuickJS for MOD scripts** | Sandboxed JS runtime prevents MODs from accessing host filesystem/network |
-| **SQLite + FastEmbed** | Zero-config embedded DB with local vector embeddings (all-MiniLM-L6-v2 ONNX) |
-| **SSE streaming** | Token-by-token delivery for real-time character responses |
-| **Intl.Segmenter for CJK** | Browser-native word segmentation for Chinese/Japanese/Korean in memory graph |
-| **Multi-provider LLM** | Unique Provider IDs allow different providers for main LLM and system LLM; presets for quick switching |
-| **Emotion persistence** | Emotion state saved to disk and restored on startup, surviving app restarts |
-| **Jailbreak placeholders** | `{{char}}` and `{{user}}` placeholder mapping in jailbreak prompts, consistent with Persona |
-| **Telegram Bot bridge** | Long-polling Telegram Bot bridges to internal services without public IP requirement |
-
----
-
-## 8. Cross-Cutting Concerns
-
-### Error Handling
-
-- **Backend** — All commands return `Result<T, String>` to the frontend
-- **Tool execution** — Failed tool results are fed back to LLM so it can respond gracefully
-- **AI fallback** — If `AIOrchestrator` init fails, the app continues without AI
-- **MOD isolation** — MOD execution errors are contained within QuickJS sandbox / iframe
-
-### Security
-
-- **`mod://` protocol** — Blocks `..` path traversal; serves only from `mods/` directory
-- **iframe sandbox** — MOD UI components run in sandboxed iframes with restricted permissions
-- **API keys** — Stored in local config files, never transmitted except to configured endpoints
-
-### Performance
-
-- **Lazy initialization** — AI infrastructure is lazy-loaded
-- **Async I/O** — All network and database operations use `tokio` async runtime
-- **PixiJS rendering** — GPU-accelerated Live2D rendering at 60fps
-- **Audio caching** — TTS results cached to avoid redundant synthesis
-- **Stream buffering** — Minimal overhead tag detection during streaming
-
----
-
-## 9. Statistics
-
-| Metric | Value |
-|---|---|
-| Frontend files | ~60 TypeScript/TSX |
-| Backend files | ~110 Rust |
-| Languages | 5 (zh, en, ja, ko, ru) |
-| TTS architecture | provider adapters + capability router + fallback chain |
-| LLM support | OpenAI-compatible + Ollama (multi-provider with presets) |
-| Built-in actions | 8 |
-| MCP transport | stdio + Streamable HTTP |
-| Remote access | Telegram Bot (long polling) |
+| Application | Kokoro Engine 0.4.0, Tauri v2, React 19, Rust 2021 |
+| Locales | 6: zh, zh-TW, en, ja, ko, ru |
+| Durable storage | SQLite plus platform-local configuration and resources |
+| Character content | kokoro, pico, seren, and template packages |
+| LLM | OpenAI-compatible, Responses, Anthropic, Ollama, llama.cpp, experimental Codex Runtime |
+| MCP | stdio, SSE compatibility, Streamable HTTP |
+| Remote access | QQ, Telegram, Discord, LINE, authenticated Webhook |
+| Extra windows | Desktop pet and synchronized speech bubble |
+
+This document describes architecture and ownership. Exact commands, fields, and emitted events remain code-defined and should be checked against the two sources of truth named at the top.


### PR DESCRIPTION
## Summary

- rewrite the architecture reference around the current React 19/Tauri v2 module boundaries and character-owned runtime model
- refresh the PRD for current providers, memory behavior, registry lifecycle, bot bridges, desktop pet, and six locales
- update the API reference with current chat, vision, memory, character, command, and event contracts
- synchronize all localized READMEs with the supported Node.js versions and shipped character/onboarding experience

## Review follow-up

- remove `camera-observation` from the IPC command table and retain it only as an event listener contract
- document chat turn correlation fields plus failure, acknowledgement, text-complete, and memory download payload shapes
- clarify the loopback-only unauthenticated Vision file server versus the authenticated generic Bot Webhook
- document the registered `character-instance-resource://` protocol and its containment constraints

## Validation

- `git diff --check`
- `npm run check:ipc` (171 invoked command names registered)
- local Markdown link and explicit anchor validation
- adversarial read-only review against the current TypeScript bridge and Rust sources